### PR TITLE
Change dependency name browsersync -> browser-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-size": "^0.3.0",
     "gulp-uglify": "^0.2.1",
     "gulp-useref": "^0.4.3",
-    "browsersync": "^0.9.1",
+    "browser-sync": "^0.9.1",
     "jshint-stylish": "^0.2.0",
     "opn": "^0.1.1",
     "wiredep": "^1.4.3"


### PR DESCRIPTION
I'm PRing this in case I'm just doing something silly here, but I couldn't install `browsersync` from npm. Was that just a typo?
