### PR TITLE
Shouldn't need to be root to npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you would like to use the optional tooling we provide:
 
 ```
 # Run to install the dependencies needed (requires Node)
-$ sudo npm install 
+$ npm install 
 
 # Build the current project
 $ gulp


### PR DESCRIPTION
Local packages should install without privilege. For future reference,
we should think about making sure there are Windows instructions here as
well.
