### PR TITLE
Add copyright headers as requested.

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!--
+This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">

--- a/app/alt-layout.html
+++ b/app/alt-layout.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!--
+This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
+-->
 <html class="no-js no-touch" itemscope itemtype="http://schema.org/Article">
     <head>
         <meta charset="utf-8">

--- a/app/basic.html
+++ b/app/basic.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!--
+This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
+-->
 <html class="no-js">
     <head>
         <meta charset="utf-8">

--- a/app/index.html
+++ b/app/index.html
@@ -1,4 +1,7 @@
 <!doctype html>
+<!--
+This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
+-->
 <html class="no-js no-touch" itemscope itemtype="http://schema.org/Article">
     <head>
         <meta charset="utf-8">

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,3 +1,22 @@
+/** 
+ * 
+ *  Web Starter Kit
+ *  Copyright 2014 Google Inc. All rights reserved.
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ * 
+ */ 
+
 (function () {
     'use strict';
     var navdrawerContainer = document.querySelector('.navdrawer-container');

--- a/app/styleguide/index.html
+++ b/app/styleguide/index.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!--
+This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
+-->
 <html lang="en" class="no-js no-touch" itemscope itemtype="http://schema.org/Article">
   <head>
     <meta charset="utf-8" />

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1,3 +1,11 @@
+/**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
 /*
  * Web Starter Kit
  *

--- a/app/styles/sass/_components/_articles-list.scss
+++ b/app/styles/sass/_components/_articles-list.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Articles list
 *

--- a/app/styles/sass/_components/_breadcrumb.scss
+++ b/app/styles/sass/_components/_breadcrumb.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Breadcrumb
 *

--- a/app/styles/sass/_components/_button.scss
+++ b/app/styles/sass/_components/_button.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Button
 *

--- a/app/styles/sass/_components/_column-list.scss
+++ b/app/styles/sass/_components/_column-list.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Column list
 *

--- a/app/styles/sass/_components/_grid.scss
+++ b/app/styles/sass/_components/_grid.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Grid
 *

--- a/app/styles/sass/_components/_guides-list.scss
+++ b/app/styles/sass/_components/_guides-list.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Guides List
 *

--- a/app/styles/sass/_components/_icon-circle.scss
+++ b/app/styles/sass/_components/_icon-circle.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Icon Circle
 *

--- a/app/styles/sass/_components/_icons.scss
+++ b/app/styles/sass/_components/_icons.scss
@@ -1,3 +1,10 @@
+/**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
 
 @font-face {
   font-family:"icons";

--- a/app/styles/sass/_components/_link.scss
+++ b/app/styles/sass/_components/_link.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Link
 *

--- a/app/styles/sass/_components/_list.scss
+++ b/app/styles/sass/_components/_list.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * List
 *

--- a/app/styles/sass/_components/_media.scss
+++ b/app/styles/sass/_components/_media.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Media - imgs/videos
 *

--- a/app/styles/sass/_components/_subsection-title.scss
+++ b/app/styles/sass/_components/_subsection-title.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * subsection__title
 *

--- a/app/styles/sass/_components/_table.scss
+++ b/app/styles/sass/_components/_table.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Table
 *

--- a/app/styles/sass/_components/_typography.scss
+++ b/app/styles/sass/_components/_typography.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Typography
 *

--- a/app/styles/sass/_global.scss
+++ b/app/styles/sass/_global.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Global
 *

--- a/app/styles/sass/_helper.scss
+++ b/app/styles/sass/_helper.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Helper
 *

--- a/app/styles/sass/_modules/_article-nav.scss
+++ b/app/styles/sass/_modules/_article-nav.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Article nav
 *

--- a/app/styles/sass/_modules/_articles-section.scss
+++ b/app/styles/sass/_modules/_articles-section.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Articles section
 *

--- a/app/styles/sass/_modules/_did-you-know.scss
+++ b/app/styles/sass/_modules/_did-you-know.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Text module
 *

--- a/app/styles/sass/_modules/_editorial-header.scss
+++ b/app/styles/sass/_modules/_editorial-header.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Editorial Header
 *

--- a/app/styles/sass/_modules/_featured-section.scss
+++ b/app/styles/sass/_modules/_featured-section.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Editorial Header
 *

--- a/app/styles/sass/_modules/_featured-spotlight.scss
+++ b/app/styles/sass/_modules/_featured-spotlight.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Editorial Header
 *

--- a/app/styles/sass/_modules/_guides-section.scss
+++ b/app/styles/sass/_modules/_guides-section.scss
@@ -1,3 +1,11 @@
+/**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
 .guides-section {
   background: $colorGrayBackground;
   text-align: center;

--- a/app/styles/sass/_modules/_highlight.scss
+++ b/app/styles/sass/_modules/_highlight.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Highlight
 *

--- a/app/styles/sass/_modules/_in-this-guide.scss
+++ b/app/styles/sass/_modules/_in-this-guide.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * In this guide
 *

--- a/app/styles/sass/_modules/_next-lessons.scss
+++ b/app/styles/sass/_modules/_next-lessons.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Next Lessons
 *

--- a/app/styles/sass/_modules/_page-header.scss
+++ b/app/styles/sass/_modules/_page-header.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Page header
 *

--- a/app/styles/sass/_modules/_quote.scss
+++ b/app/styles/sass/_modules/_quote.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Quote
 *

--- a/app/styles/sass/_modules/_related-guides.scss
+++ b/app/styles/sass/_modules/_related-guides.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Related items
 *

--- a/app/styles/sass/_modules/_related-items.scss
+++ b/app/styles/sass/_modules/_related-items.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Related items
 *

--- a/app/styles/sass/_modules/_summary-header.scss
+++ b/app/styles/sass/_modules/_summary-header.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Editorial Header
 *

--- a/app/styles/sass/_modules/_toc.scss
+++ b/app/styles/sass/_modules/_toc.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Table of contents
 *

--- a/app/styles/sass/_pages/_page-resources.scss
+++ b/app/styles/sass/_pages/_page-resources.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Resources page
 *

--- a/app/styles/sass/_pages/_styleguide.scss
+++ b/app/styles/sass/_pages/_styleguide.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Styleguide
 *

--- a/app/styles/sass/_themed.scss
+++ b/app/styles/sass/_themed.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Themed styles
 *

--- a/app/styles/sass/_utils.scss
+++ b/app/styles/sass/_utils.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Utils
 *

--- a/app/styles/sass/styles.scss
+++ b/app/styles/sass/styles.scss
@@ -1,4 +1,12 @@
 /**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
+/**
 *
 * Main Stylesheet
 *

--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -1,3 +1,11 @@
+/**
+ * 
+ * This content is licensed under Creative Commons Attribution 4.0. 
+ * The full text of the license can be located at 
+ * http://creativecommons.org/licenses/by/4.0/legalcode
+ * 
+ */
+
 /*
  * Styleguide
  *

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,22 @@
+/** 
+ * 
+ *  Web Starter Kit
+ *  Copyright 2014 Google Inc. All rights reserved.
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ * 
+ */
+ 
 'use strict';
 var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();


### PR DESCRIPTION
The open-source team at Google have requested that all HTML, CSS and JS files include the relevant copyright headers before we can flip the switch on moving this to github.com/google.

Adding them in as requested.
