### PR TITLE
Remove license info from `404.html`

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -1,7 +1,4 @@
 <!doctype html>
-<!--
-This content is licensed under Creative Commons Attribution 4.0. The full text of the license can be located at http://creativecommons.org/licenses/by/4.0/legalcode
--->
 <html lang="en">
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
The license information is already provided in the `LICENSE` file.

(Change similar to: https://github.com/google/web-starter-kit/commit/257ec33f91c3f3fc345cb1eca6c39bd052f7f181).
