### PR TITLE
Fix for a grid issue

### DIFF
--- a/app/styles/components/_components/_grid.scss
+++ b/app/styles/components/_components/_grid.scss
@@ -72,6 +72,7 @@
   }
 
   .g-medium--last { margin-right: 0; }
+  .g-medium--last + .g-medium--half { clear: left; }
 
   .g--pull-half { margin-right: 50% + $mediumGutterWidth/2; }
 }

--- a/app/styles/components/components.css
+++ b/app/styles/components/components.css
@@ -1,6 +1,6 @@
 /**
 *
-* Main Stylesheet
+* Main Stylesheet For Visual Style Guide
 *
 **/
 @import url("//fonts.googleapis.com/css?family=Roboto+Condensed:400,300,700,900");
@@ -184,6 +184,7 @@ figure {
  * Address differences between Firefox and other browsers.
  */
 hr {
+  -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
@@ -324,6 +325,8 @@ input[type="number"]::-webkit-outer-spin-button {
 input[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
   /* 2 */
   box-sizing: content-box;
 }
@@ -391,6 +394,8 @@ blockquote {
 *
 **/
 * {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
   -ms-box-sizing: border-box;
   box-sizing: border-box;
 }
@@ -419,7 +424,14 @@ body:after {
   width: 100%;
   z-index: 9;
   display: none;
+  background-image: -moz-linear-gradient(top, transparent 95%, rgba(0, 0, 0, 0.15) 100%);
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(95%, transparent), color-stop(100%, rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, transparent 95%, rgba(0, 0, 0, 0.15) 100%);
+  background-image: -o-linear-gradient(top, transparent 95%, rgba(0, 0, 0, 0.15) 100%);
+  background-image: -ms-linear-gradient(top, transparent 95%, rgba(0, 0, 0, 0.15) 100%);
   background-image: linear-gradient(top, rgba(0, 0, 0, 0.15) 95%, rgba(0, 0, 0, 0.15) 100%);
+  -webkit-background-size: 100% 26px;
+  -moz-background-size: 100% 26px;
   -ms-background-size: 100% 26px;
   background-size: 100% 26px;
 }
@@ -434,6 +446,8 @@ pre {
 }
 
 .main-container {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
   -ms-box-sizing: content-box;
   box-sizing: content-box;
   position: relative;
@@ -458,6 +472,8 @@ pre {
 }
 
 .container {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
   -ms-box-sizing: content-box;
   box-sizing: content-box;
   position: relative;
@@ -483,6 +499,8 @@ pre {
 
 @media only screen and (min-width: 620px) {
   .container-medium {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
     -ms-box-sizing: content-box;
     box-sizing: content-box;
     position: relative;
@@ -509,6 +527,8 @@ pre {
 
 @media only screen and (max-width: 619px) {
   .container-small {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
     -ms-box-sizing: content-box;
     box-sizing: content-box;
     position: relative;
@@ -689,6 +709,8 @@ pre {
 }
 
 .highlight-module__container {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
   -ms-box-sizing: content-box;
   box-sizing: content-box;
   padding-left: 5%;
@@ -1038,6 +1060,8 @@ pre {
   padding-bottom: 78px;
   color: #ffffff;
   margin-bottom: 26px;
+  -webkit-box-shadow: inset 0 2px 0 0 white;
+  -moz-box-shadow: inset 0 2px 0 0 white;
   -ms-box-shadow: inset 0 2px 0 0 white;
   box-shadow: inset 0 2px 0 0 white;
 }
@@ -1678,6 +1702,10 @@ pre {
     margin-right: 0;
   }
 
+  .g-medium--last + .g-medium--half {
+    clear: left;
+  }
+
   .g--pull-half {
     margin-right: 52.25%;
   }
@@ -1775,6 +1803,8 @@ pre {
   pointer-events: none;
 }
 .debug .grid-overlay {
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
   -ms-box-sizing: content-box;
   box-sizing: content-box;
   position: relative;
@@ -1977,6 +2007,9 @@ li > p {
   font-weight: 600;
   text-decoration: none;
   outline: 0;
+  -webkit-transition: none;
+  -moz-transition: none;
+  -ms-transition: none;
   transition: none;
 }
 .button:hover, .button--primary:hover, .button--secondary:hover, .button--secondary-variation:hover {
@@ -2060,10 +2093,7 @@ ol > li:nth-child(10n) ~ li:before, ol > li:nth-child(10n):before {
   content: counter(list);
 }
 
-ul ol {
-  padding-top: 0;
-}
-
+ul ol,
 ol ul {
   padding-top: 0;
 }
@@ -2526,7 +2556,7 @@ td:last-child:after {
 }
 
 .table-3 col {
-  width: 229.3333333333px;
+  width: 229.33333px;
 }
 @media only screen and (min-width: 800px) {
   .table-3 col {
@@ -2689,6 +2719,7 @@ object {
 }
 @media only screen and (min-width: 620px) {
   .guides-list {
+    display: -moz-box;
     display: -webkit-flex;
     display: flex;
     -webkit-justify-content: space-between;
@@ -2707,6 +2738,7 @@ object {
 }
 @media only screen and (min-width: 620px) {
   .guides-list__item {
+    display: -moz-box;
     display: -webkit-flex;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
The homepage grid don't clear floating block after a "new line" ("last"
item + next item).
It's create a break in the grid, in Firefox and some version of Chrome
browsers.

Sorry for the  **components.css completion**, it's from my tool setting (auto-prefixer), but **you can keep the _grid.scss only** ;)
