### PR TITLE
Update BrowserSync version to 1.0.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,7 @@ gulp.task('clean', function (cb) {
 
 // Watch Files For Changes & Reload
 gulp.task('serve', function () {
-    browserSync.init(null, {
+    browserSync.init({
         server: {
             baseDir: ['app', '.tmp']
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "browser-sync": "^0.9.1",
+    "browser-sync": "^1.0.0",
     "gulp": "^3.6.0",
     "gulp-autoprefixer": "^0.0.7",
     "gulp-cache": "^0.1.1",


### PR DESCRIPTION
BrowserSync 1.0.0 brings a simpler API, better performance & stability, important client-side bug-fixes &  support for public URLS & BrowserStack.
