### PR TITLE
IE10 and IE11 have pointer events, not touch

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -34,6 +34,8 @@
         navdrawerContainer.classList.toggle('open');
     }
 
+    main.addEventListener('MSPointerDown', closeMenu);
+    main.addEventListener('pointerdown', closeMenu);
     main.addEventListener('ontouchstart', closeMenu);
     main.addEventListener('click', closeMenu);
     menuBtn.addEventListener('click', toggleMenu);


### PR DESCRIPTION
This project targets IE10 and IE11, it should then use touch related events counterpart when it's possible to be fair with these browsers too and preserve the initial touch related intent/behavior.
