### PR TITLE
when it's touch, don't' click too

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -39,6 +39,9 @@
     menuBtn.addEventListener('click', toggleMenu);
     navdrawerContainer.addEventListener('click', function (event) {
         if (event.target.nodeName === 'A' || event.target.nodeName === 'LI') {
+            if (event.type !== 'click') {
+                event.preventDefault();
+            }
             closeMenu();
         }
     });


### PR DESCRIPTION
The usage of `event.preventDefault()` should avoid the triggering of the `click` event later, ensuring that `closeMenu` is called once instead of twice when `touch` (or `pointerdown`) is performed instead of click.
