### PR TITLE
X-UA-Compatible meta tag missing on some HTML pages

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Page Not Found</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
     <style>
       * {

--- a/app/basic.html
+++ b/app/basic.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
     <title></title>

--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="A front-end template that helps you build fast, modern mobile web apps.">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
     <title>Web Starter Kit</title>


### PR DESCRIPTION
The X-UA-Compatible meta tag is missing on some HTML pages in the Web Starter Kit.

This tag allows web authors to choose what version of Internet Explorer the page should be rendered as.  Edge mode in particular tells Internet Explorer to display content in the highest mode available.  With Internet Explorer 9, this is equivalent to IE9 mode.  If a future release of Internet Explorer supported a higher compatibility mode, pages set to edge mode would appear in the highest mode supported by that version.  Those same pages would still appear in IE9 mode when viewed with Internet Explorer 9.
