### PR TITLE
Fixed so that gulp runs jshint more than once

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ gulp.task('jshint', function () {
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
     .pipe($.jshint.reporter('fail'))
-    .pipe(reload({stream: true, once: true}));
+    .pipe(reload({stream: true}));
 });
 
 // Optimize Images


### PR DESCRIPTION
I removed `once: true` because it would only lint the jsfile once and just hang. After removing that I get behavior which I expect. (But I've never used gulp before).
