### PR TITLE
Fixed so that gulp runs images more than once

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task('images', function () {
       interlaced: true
     })))
     .pipe(gulp.dest('dist/images'))
-    .pipe(reload({stream: true, once: true}))
+    .pipe(reload({stream: true}))
     .pipe($.size({title: 'images'}));
 });
 


### PR DESCRIPTION
I noticed gulp only running the 'images' task once, so I removed `once: true` from that task in `gulpfile.js`.

This shows output whenever you add an image to the `apps/images/` directory, but I'm not sure if the output is correct, so I'm not sure if you want to merge it yet:
*edit: oh, and I get this out put after I `wget awesome-photo.jpg` into the `app/images/` folder

```
[19:29:30] Starting 'images'...
[BS] File Changed: space.jpg
[BS] Injecting file into all connected browsers...
[BS] File Changed: awesome-photo.jpg
[BS] Injecting file into all connected browsers...
[BS] File Changed: awesome-photo.jpg
[BS] Injecting file into all connected browsers...
[BS] File Changed: awesome-photo.jpg
[BS] Injecting file into all connected browsers...
[BS] File Changed: hamburger.svg
[BS] Injecting file into all connected browsers...
[BS] File Changed: icons
[BS] Reloading all connected browsers...
[BS] File Changed: search.svg
[BS] Injecting file into all connected browsers...
[BS] File Changed: space.jpg
[BS] Injecting file into all connected browsers...
[BS] File Changed: touch
[BS] Reloading all connected browsers...
[BS] File Changed: icons-hinted.ttf
[BS] Reloading all connected browsers...
[BS] File Changed: icons.eot
[BS] Reloading all connected browsers...
[BS] File Changed: icons.svg
[BS] Injecting file into all connected browsers...
[BS] File Changed: icons.ttf
[BS] Reloading all connected browsers...
[BS] File Changed: icons.woff
[BS] Reloading all connected browsers...
[BS] File Changed: icons.woff2
[BS] Reloading all connected browsers...
[BS] File Changed: placeholder--medium.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: placeholder--small.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: placeholder--wide.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: apple-touch-icon-114x114-precomposed.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: apple-touch-icon-144x144-precomposed.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: apple-touch-icon-57x57-precomposed.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: apple-touch-icon-72x72-precomposed.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: ms-touch-icon-144x144-precomposed.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: touch-icon-196x196.png
[BS] Injecting file into all connected browsers...
[BS] File Changed: touch-icon-57x57.png
[BS] Injecting file into all connected browsers...
[19:29:33] gulp-size: 'images' total 22.57 MB
[19:29:33] Finished 'images' after 3.04 s
```

Without this change I only get the output:

```
[19:29:30] Starting 'images'...
```

and no other output if I add additional pictures. 
