### PR TITLE
Uses document.querySelector directly, rather than wrapping it.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -19,9 +19,7 @@
 (function () {
   'use strict';
 
-  var querySelector = function (selector) {
-    return document.querySelector(selector);
-  };
+  var querySelector = document.querySelector.bind(document);
 
   var navdrawerContainer = querySelector('.navdrawer-container');
   var appbarElement = querySelector('.app-bar');


### PR DESCRIPTION
There appears to be no need to wrap it in a function, which only directly calls the querySelector itself.
