### PR TITLE
Fixed the article section by adding padding

### DIFF
--- a/app/styles/components/_modules/_articles-section.scss
+++ b/app/styles/components/_modules/_articles-section.scss
@@ -13,7 +13,6 @@
 .articles-count {
   color: $colorBlue;
   font-family: $fontHighlight;
-  margin-top: -($lineHeight*2);
   font-weight: 400;
 }
 

--- a/app/styles/components/components.css
+++ b/app/styles/components/components.css
@@ -1142,7 +1142,6 @@ pre {
 .articles-count {
   color: #3372df;
   font-family: "Roboto Condensed", Helvetica, sans-serif;
-  margin-top: -52px;
   font-weight: 400;
 }
 


### PR DESCRIPTION
I added padding that was missing in the styles of .articles-section. Please take a look. This fixes the problem mentioned in issue #121.

You can merge or manually add the code, up to you.
