### PR TITLE
Adds `npm test` and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - '0.10'

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "private": true
+  "private": true,
+  "scripts": {
+    "test": "gulp"
+  }
 }


### PR DESCRIPTION
Runs the default gulp task on `npm test` and adds a node_js `.travis.yml` config, as suggested in #137.
