### PR TITLE
Adds .travis.yml to files to remove for the 'boilerplate-only option'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you find yourself running into issues during installation or running the tool
 
 ## A Boilerplate-only Option
 
-If you would prefer not to use any of our tooling, delete the following files from the project: `package.json`, `gulpfile.js`, `.jshintrc`. You can now safely use the boilerplate with an alternative build-system or no build-system at all if you choose.
+If you would prefer not to use any of our tooling, delete the following files from the project: `package.json`, `gulpfile.js`, `.jshintrc` and `.travis.yml`. You can now safely use the boilerplate with an alternative build-system or no build-system at all if you choose.
 
 ## Inspiration
 


### PR DESCRIPTION
Nitpick, but users should probably remove `.travis.yml` as well if they wish to exclude all tooling.
