### PR TITLE
gitignored a few more types of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,20 @@
-node_modules
-.sass-cache
+# Generated
 dist
+
+# Dependencies
+node_modules
+
+# Temp
+.sass-cache
 .tmp
+
+# Editor
+*.sublime-workspace
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+logs
+*.log


### PR DESCRIPTION
Added .gitignore rules for OS specific files, Sublime Text workspaces and Node error logs.
