### PR TITLE
Move Contributing guide to a CONTRIBUTING.md file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+CONTRIBUTING.md export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+*[Website](https://developers.google.com/web/starter-kit/) related issues should be filed on the [Web Fundamentals](https://github.com/google/WebFundamentals/issues/new) issue tracker.*
+
+Web Starter Kit is an open source project. It is licensed using the
+[Apache Software License 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+We appreciate pull requests, here are our guidelines:
+
+1. File a bug at https://github.com/google/web-starter-kit/issues (if there
+isn’t one already). If your patch is going to be large it might be a good idea
+to get the discussion started early. We are happy to discuss it in a new issue beforehand.
+1. Make sure that patches provide justification for why they should be merged. Web Starter Kit is an opinionated project and as such, patches which add support for alternative choices to those we prescribe are not guaranteed to land.
+1. Due to legal reasons, all contributors must sign a contributor license
+agreement, either for an
+[individual](http://code.google.com/legal/individual-cla-v1.0.html) or
+[corporation](http://code.google.com/legal/corporate-cla-v1.0.html), before a
+patch can be accepted.
+1. We ask that you squash all the commits together before pushing.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Web Starter Kit is inspired by [Mobile HTML5 Boilerplate](http://html5boilerplat
 
 ## Contributing
 
-Contributions, questions and comments are all welcome and encouraged. For code contributions to Web Starter Kit, please see our [Contribution guide](https://github.com/google/web-starter-kit/wiki/Contributing) before submitting a patch. For issues or patches related to the [homepage](https://developers.google.com/web/starter-kit/), please file an issue over on [Web Fundamentals](https://github.com/google/WebFundamentals/issues/new).
+Contributions, questions and comments are all welcome and encouraged. For code contributions to Web Starter Kit, please see our [Contribution guide](CONTRIBUTING.md) before submitting a pull request. [Website](https://developers.google.com/web/starter-kit/) related issues should be filed on the [Web Fundamentals](https://github.com/google/WebFundamentals/issues/new) issue tracker.
 
 ## License
 


### PR DESCRIPTION
So it shows up as a notice when people open issues/PRs

https://github.com/blog/1184-contributing-guidelines

@addyosmani 
