### PR TITLE
Adds missing closing section tag around highlights.

### DIFF
--- a/app/styleguide/index.html
+++ b/app/styleguide/index.html
@@ -706,42 +706,44 @@
         </div>
       </div>
 
-    <div class="code-sample">
-    <div class="highlight-module  highlight-module--left   highlight-module--learning  ">
-      <div class="highlight-module__container  icon-star ">
-        <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--push-1   ">
-          <p class="highlight-module__title"> Key Takeaways</p>
-          <p class="highlight-module__text"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>
+      <div class="code-sample">
+        <div class="highlight-module  highlight-module--left   highlight-module--learning  ">
+          <div class="highlight-module__container  icon-star ">
+            <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--push-1   ">
+              <p class="highlight-module__title"> Key Takeaways</p>
+              <p class="highlight-module__text"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-    </div>
 
-    <div class="code-sample">
-      <div class="highlight-module  highlight-module--right   highlight-module--remember  ">
-        <div class="highlight-module__container  icon-exclamation ">
-          <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--pull-1   ">
-            <p class="highlight-module__title"> Remember</p>
+      <div class="code-sample">
+        <div class="highlight-module  highlight-module--right   highlight-module--remember  ">
+          <div class="highlight-module__container  icon-exclamation ">
+            <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--pull-1   ">
+              <p class="highlight-module__title"> Remember</p>
               <ul class="highlight-module__list">
                 <li>Lorem ipsum dolor sit amet</li>
                 <li>Fugit itaque sapiente earum quo expedita</li>
                 <li>labore aliquam cupiditate veritatis nihil</li>
               </ul>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="code-sample">
-      <div class="highlight-module  highlight-module--left   highlight-module--remember  ">
-        <div class="highlight-module__container  icon-exclamation ">
-          <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--push-1   ">
-            <p class="highlight-module__title"> Remember</p>
-            <p class="highlight-module__text"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>
+      <div class="code-sample">
+        <div class="highlight-module  highlight-module--left   highlight-module--remember  ">
+          <div class="highlight-module__container  icon-exclamation ">
+            <div class="highlight-module__content   g-wide--push-1 g-wide--pull-1  g-medium--push-1   ">
+              <p class="highlight-module__title"> Remember</p>
+              <p class="highlight-module__text"> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+    </section>
 
     <div class="container">
       <h3>Code Samples</h3>


### PR DESCRIPTION
There was an unbalanced `<section>` tag, opened after the highlights anchor [L696](https://github.com/google/web-starter-kit/blob/master/app/styleguide/index.html#L696). The subsequent indentation suggests that only the first `<div class="code-sample">` block should be within this `<section>`, but this PR closes the tag after the life examples and before the code examples, consistent with the other sections.

The diff, ignoring correspondingly fixed indentation, can be seen at by appending [`w=1`](https://github.com/google/web-starter-kit/pull/152/files?w=1) to the URL.
