### PR TITLE
Fixed the link to the troubleshooting page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This is not to say that Web Starter Kit cannot be used in browsers older than th
 
 ## Troubleshooting
 
-If you find yourself running into issues during installation or running the tools, please check our [Troubleshooting](https://github.com/google/web-starter-kit) guide and then open an [issue](https://github.com/google/web-starter-kit/issues). We would be happy to discuss how they can be solved.
+If you find yourself running into issues during installation or running the tools, please check our [Troubleshooting](https://github.com/google/web-starter-kit/wiki/Troubleshooting) guide and then open an [issue](https://github.com/google/web-starter-kit/issues). We would be happy to discuss how they can be solved.
 
 ## A Boilerplate-only Option
 


### PR DESCRIPTION
Previously linked to the main GitHub repository page, now it links directly to the troubleshooting page in the wiki.
