### PR TITLE
Bump gulp-cache to 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "del": "^0.1.0",
     "gulp": "^3.6.0",
     "gulp-autoprefixer": "^0.0.7",
-    "gulp-cache": "^0.1.1",
+    "gulp-cache": "^0.2.0",
     "gulp-csso": "^0.2.6",
     "gulp-flatten": "^0.0.2",
     "gulp-if": "^1.2.1",


### PR DESCRIPTION
Changelog available here:
https://github.com/jgable/gulp-cache/compare/3b44956e60b4a96905ade5391f730f03604ae27c...0.2.0

Works for me. @sindresorhus okay with you?
