### PR TITLE
Give server preference to files in .tmp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ gulp.task('serve', function () {
   bs = browserSync({
     notify: false,
     server: {
-      baseDir: ['app', '.tmp']
+      baseDir: ['.tmp', 'app']
     }
   });
 


### PR DESCRIPTION
From my testing, the browserSync server prefers files in app over files in .tmp when they have the same name. .tmp files should be preferred, since any file in .tmp has been processed in some way (e.g., a main.css file that's autoprefixed into .tmp, or an index.html that contains some templating that's precompiled into .tmp).

I haven't played with the starter kit too much, so excuse me if I missed something.
