### PR TITLE
Add uglify-save-license

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ var runSequence = require('run-sequence');
 var browserSync = require('browser-sync');
 var pagespeed = require('psi');
 var reload = browserSync.reload;
+var saveLicense = require('uglify-save-license');
 
 // Lint JavaScript
 gulp.task('jshint', function () {
@@ -92,7 +93,7 @@ gulp.task('html', function () {
   return gulp.src('app/**/*.html')
     .pipe($.useref.assets({searchPath: '{.tmp,app}'}))
     // Concatenate And Minify JavaScript
-    .pipe($.if('*.js', $.uglify()))
+    .pipe($.if('*.js', $.uglify({ preserveComments: saveLicense })))
     // Concatenate And Minify Styles
     .pipe($.if('*.css', $.csso()))
     // Remove Any Unused CSS

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "jshint-stylish": "^0.2.0",
     "opn": "^0.1.1",
     "psi": "^0.0.4",
-    "run-sequence": "^0.3.6"
+    "run-sequence": "^0.3.6",
+    "uglify-save-license": "^0.4.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Cureently, the optimized JS file doesn't include any license comments, though the original JS file is licensed under [the Apache License 2.0](https://github.com/google/web-starter-kit/blob/f4b1aa9e5a42ace6085293f138a62987644f2fc7/app/scripts/main.js#L1-L18).

To fix this, I added [uglify-save-license](https://github.com/shinnn/uglify-save-license) to this project.
It can preserve only license comments, even if the license comment has no [_preservation_ directives](https://github.com/mishoo/UglifyJS2#keeping-copyright-notices-or-other-comments) such as `@license`, `@preserve` and `/*!`.
