### PR TITLE
Allow gulp task list to be extended.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,3 +143,7 @@ gulp.task('pagespeed', pagespeed.bind(null, {
   url: 'https://example.com',
   strategy: 'mobile'
 }));
+
+// Load custom tasks
+var requireDir = require('require-dir');
+var dir = requireDir('./tasks');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jshint-stylish": "^0.2.0",
     "opn": "^0.1.1",
     "psi": "^0.0.4",
+    "require-dir": "^0.1.0",
     "run-sequence": "^0.3.6"
   },
   "engines": {


### PR DESCRIPTION
As a starter kit, we want users to be able to customize.
As a source-based distribution we want users to stay updated.
By allowing users to customize web-starter-kit gulp
without editing gulpfile.js, they can rebase or merge future updates.

Impl: Apply gulp recipe 'Split tasks across multiple files'
https://github.com/gulpjs/gulp/blob/master/docs/recipes/
split-tasks-across-multiple-files.md
