### PR TITLE
Preserve JavaScript license comment at optimizing

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,4 +1,4 @@
-/**
+/*!
  *
  *  Web Starter Kit
  *  Copyright 2014 Google Inc. All rights reserved.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ gulp.task('html', function () {
   return gulp.src('app/**/*.html')
     .pipe($.useref.assets({searchPath: '{.tmp,app}'}))
     // Concatenate And Minify JavaScript
-    .pipe($.if('*.js', $.uglify()))
+    .pipe($.if('*.js', $.uglify({preserveComments: 'some'})))
     // Concatenate And Minify Styles
     .pipe($.if('*.css', $.csso()))
     // Remove Any Unused CSS


### PR DESCRIPTION
I updated [gulp-uglify](https://github.com/terinjokes/gulp-uglify) option and added a `!` to the comment to preserve license and copyright notice.

This PR fixes the problem mentioned in #190.
