### PR TITLE
Removes unused 'require-dir' package.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,6 +143,3 @@ gulp.task('pagespeed', pagespeed.bind(null, {
   url: 'https://example.com',
   strategy: 'mobile'
 }));
-
-// Load custom tasks from the `tasks` directory
-try { require('require-dir')('tasks'); } catch (err) {}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "jshint-stylish": "^0.2.0",
     "opn": "^0.1.1",
     "psi": "^0.0.4",
-    "require-dir": "^0.1.0",
     "run-sequence": "^0.3.6"
   },
   "engines": {


### PR DESCRIPTION
There are currently no tasks under `/tasks/`, and I don't believe there will be
anywhere in the near future - so might as well clean up the unnecessary package.
