### PR TITLE
Adds a gulp serve:dist command that uses the dist build process.  Fixes #216

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -136,7 +136,13 @@ gulp.task('serve', function () {
 });
 
 // Build and serve the output from the dist build
-gulp.task('serve:dist', ['default'], $.serve('dist'));
+gulp.task('serve:dist', ['default'], function() {
+  browserSync.init(null, {
+    server: {
+      baseDir: "./dist/"
+    }
+  });
+});
 
 // Build Production Files, the Default Task
 gulp.task('default', ['clean'], function (cb) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "opn": "^0.1.2",
     "psi": "^0.0.4",
     "require-dir": "^0.1.0",
-    "run-sequence": "^0.3.6",
-    "gulp-serve": "^0.2.0"
+    "run-sequence": "^0.3.6"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Lets you quickly serve the dist folder by issuing `gulp serve:dist`.  It adds in a new dependency: grunt-serve, and hosts on port :3000 

Motivation is to help solve #215.  Fixes #216 
