### PR TITLE
Potential fix for #79

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -218,6 +218,12 @@ main {
     position: relative;
   }
 
+  .app-bar.open,
+  .app-bar.open ~ main {
+    -webkit-transform: translate(0px, 0);
+    transform: translate(0px, 0);
+  }
+  
   .app-bar-container {
     display: block;
     height: 130px;


### PR DESCRIPTION
In the 1200px media query, negate the `.app-bar.open, .app-bar.open ~ main transform` to remove the white area (~250px out) displayed. This generally seems to be a FF only issue.

Fixes #79 
