### PR TITLE
minifyHtml should only run on html files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ gulp.task('html', function () {
     // Update Production Style Guide Paths
     .pipe($.replace('components/components.css', 'components/main.min.css'))
     // Minify Any HTML
-    .pipe($.minifyHtml())
+    .pipe($.if('*.html', $.minifyHtml()))
     // Output Files
     .pipe(gulp.dest('dist'))
     .pipe($.size({title: 'html'}));


### PR DESCRIPTION
Got some weird errors when I was trying to get JS concatenation and minification to work, spent more time than I'd like to admit to debug uglify.

Turns out, the HTML minifier maybe shouldn't run over the whole pipe ;)
