### PR TITLE
Various styling fixes

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -151,7 +151,7 @@ button.menu img {
   color: #fefefe;
   -webkit-transform: translate(-250px, 0);
           transform: translate(-250px, 0);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .navdrawer-container.open {
@@ -223,7 +223,7 @@ main {
 }
 
 /** Larger Screens - desktops and tablets **/
-@media all and (min-width: 1200px) {
+@media all and (min-width: 990px) {
   .app-bar {
     position: relative;
   }
@@ -316,35 +316,5 @@ main {
   .navdrawer-container {
     position: relative;
     margin-top: 0;
-  }
-}
-
-@media all and (min-width: 1200px) and (max-width: 800px) {
-  .app-bar .logo {
-    float: none;
-    width: 100%;
-    line-height: normal;
-    text-align: center;
-    padding-top: 36px;
-  }
-
-  .app-bar-container {
-    height: auto;
-  }
-
-  .app-bar-actions {
-    width: 100%;
-  }
-
-  .navdrawer-container {
-    padding: 0 16px;
-    overflow-y: auto;
-  }
-
-  .navdrawer-container li {
-    -webkit-flex: 1;
-        -ms-flex: 1;
-            flex: 1;
-    text-align: center;
   }
 }


### PR DESCRIPTION
1) Removes a style block which does not appear to be used anymore now that we're not using pixel widths to determine screen size. Related to #250. I tested this on FF and Chrome and could not see any difference with the block removed. Verification on further browsers would be useful.

2) Switches our current min-width of 1200px to the more sensible 990px as we currently snap too early on desktop. Starts to address #237 

3) Fixed an issue with the navigation bar where we currently display the overflow scrollbar too early. Using auto it should now only be shown when the window size vertically gets too small or there is sufficient content to force a scroll bar to be needed.
