### PR TITLE
Add WebStorm rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules
 .sass-cache
 dist
 .tmp
+
+## WebStrom
+.idea/
+*.ipr
+*.iws
+*.iml


### PR DESCRIPTION
WebStorm is one of the most popular web app development IDEs, right? If so, why not to add .gitignore settings for it?
