### PR TITLE
Add 'auto' to the Google Analytics tracker create method.

### DIFF
--- a/app/basic.html
+++ b/app/basic.html
@@ -38,7 +38,7 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-XXXXX-X');
+      ga('create', 'UA-XXXXX-X', 'auto');
       ga('send', 'pageview');
     </script>
     <!-- Built with love using Web Starter Kit -->

--- a/app/index.html
+++ b/app/index.html
@@ -69,7 +69,7 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-XXXXX-X');
+      ga('create', 'UA-XXXXX-X', 'auto');
       ga('send', 'pageview');
     </script>
     <!-- Built with love using Web Starter Kit -->


### PR DESCRIPTION
Google Analytics supports [automatic cookie domain configuration](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains#auto), and this is now officially part of the recommended [GA code snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/).

When this parameter is omitted (as it was prior to this pull request), Google Analytics will default to using `location.hostname`, which will include the subdomain. This prevents websites with multiple subdomains from being able to automatically track unique users across those subdomains.
