### PR TITLE
Remove duplicated line-height in .logo

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -70,7 +70,6 @@ body.open {
   float: none;
   max-width: none;
   font-weight: 300;
-  line-height: 60px;
 }
 
 .app-bar .logo a {


### PR DESCRIPTION
`line-height: 60px;` occurs two times in `.app-bar .logo`
