### PR TITLE
remove repeated declaration block and unnecessary overridden css

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -276,7 +276,7 @@ main {
     position: relative;
     width: 100%;
     height: auto;
-    margin-top: 130px;
+    margin-top: 0;
     -webkit-transform: translate(0, 0);
             transform: translate(0, 0);
     -webkit-transition: none;
@@ -311,11 +311,6 @@ main {
 
   body {
     overflow-y: scroll;
-  }
-
-  .navdrawer-container {
-    position: relative;
-    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
This PR removes the redundancy on CSS declaration block for `.navdrawer-container` element and also organize the CSS avoiding unused values being overridden
