### PR TITLE
remove unnecessary css that was being overridden

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -267,11 +267,6 @@ main {
     display: none;
   }
 
-  nav {
-    display: block;
-    margin-top: 130px;
-  }
-
   .navdrawer-container {
     position: relative;
     width: 100%;


### PR DESCRIPTION
Remove generic `nav` css declaration that was relative to `.navdrawer-container` element. `margin-top: 130px` was being overridden and `display: block` is already defined on normalize
