### PR TITLE
add SUIT CSS name convention to old .navdrawer-container and inner elements

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -43,12 +43,12 @@
       </div>
     </header>
 
-    <nav class="navdrawer-container promote-layer">
-      <h4>Navigation</h4>
-      <ul>
-        <li><a href="#hello">Hello</a></li>
-        <li><a href="#get-started">Get Started</a></li>
-        <li><a href="styleguide/index.html">Style Guide</a></li>
+    <nav class="Navdrawer promote-layer">
+      <h4 class="Navdrawer-title">Navigation</h4>
+      <ul class="Navdrawer-list">
+        <li class="Navdrawer-item"><a href="#hello">Hello</a></li>
+        <li class="Navdrawer-item"><a href="#get-started">Get Started</a></li>
+        <li class="Navdrawer-item"><a href="styleguide/index.html">Style Guide</a></li>
       </ul>
     </nav>
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -21,7 +21,7 @@
 
   var querySelector = document.querySelector.bind(document);
 
-  var navdrawerContainer = querySelector('.navdrawer-container');
+  var navdrawerContainer = querySelector('.Navdrawer');
   var body = document.body;
   var appbarElement = querySelector('.app-bar');
   var menuBtn = querySelector('.menu');
@@ -36,8 +36,8 @@
   function toggleMenu() {
     body.classList.toggle('open');
     appbarElement.classList.toggle('open');
-    navdrawerContainer.classList.toggle('open');
-    navdrawerContainer.classList.add('opened');
+    navdrawerContainer.classList.toggle('is-open');
+    navdrawerContainer.classList.add('is-opened');
   }
 
   main.addEventListener('click', closeMenu);

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -140,7 +140,12 @@ button.menu img {
   font-size: 19px;
 }
 
-.navdrawer-container {
+.app-bar, .Navdrawer.is-opened, main {
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+          transition: transform 0.3s ease-out;
+}
+
+.Navdrawer {
   z-index: 1;
   position: fixed;
   top: 0;
@@ -154,35 +159,30 @@ button.menu img {
   overflow-y: auto;
 }
 
-.navdrawer-container.open {
+.Navdrawer.is-open {
   -webkit-transform: translate(0, 0);
           transform: translate(0, 0);
 }
 
-.app-bar, .navdrawer-container.opened, main {
-  -webkit-transition: -webkit-transform 0.3s ease-out;
-          transition: transform 0.3s ease-out;
-}
-
-.navdrawer-container h4,
-.navdrawer-container ul li a {
+.Navdrawer-title,
+.Navdrawer-item a {
   height: auto;
   padding: 17px 20px;
   line-height: 1.4;
 }
 
-.navdrawer-container h4 {
+.Navdrawer-title {
   background-color: white;
   color: #3367D6;
 }
 
-.navdrawer-container ul {
+.Navdrawer-list {
   padding: 0;
   margin: 0;
   list-style-type: none;
 }
 
-.navdrawer-container ul li a {
+.Navdrawer-item a {
   display: block;
   text-decoration: none;
   color: white;
@@ -191,27 +191,27 @@ button.menu img {
   white-space: nowrap;
 }
 
-.navdrawer-container ul li {
+.Navdrawer-item {
   border-bottom-style: solid;
   border-width: 1px;
   border-color: white;
   padding: 0;
 }
 
-.navdrawer-container ul li::before {
+.Navdrawer-item::before {
   content: none;
 }
 
-.navdrawer-container ul li a:hover {
+.Navdrawer-item a:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
-.navdrawer-container ul li a:focus {
+.Navdrawer-item a:focus {
   background-color: rgba(255, 255, 255, 0.3);
   outline: 0;
 }
 
-.navdrawer-container ul li a:active {
+.Navdrawer-item a:active {
   background-color: rgba(255, 255, 255, 0.4);
 }
 
@@ -272,7 +272,7 @@ main {
     margin-top: 130px;
   }
 
-  .navdrawer-container {
+  .Navdrawer {
     position: relative;
     width: 100%;
     height: auto;
@@ -284,11 +284,11 @@ main {
     overflow-y: auto;
   }
 
-  .navdrawer-container h4 {
+  .Navdrawer-title {
     display: none;
   }
 
-  .navdrawer-container ul {
+  .Navdrawer-list {
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
@@ -299,7 +299,7 @@ main {
             flex-direction: row;
   }
 
-  .navdrawer-container ul li {
+  .Navdrawer-item {
     border: none;
   }
 


### PR DESCRIPTION
This PR address two issues:
1. Add SUIT CSS name convention to old `.navdrawer-container` element with its own modifiers, descendants and states
2. Be more specific on CSS declarations for elements on `.navdrawer-container`. This comes from the need of adding a social network widget on the menu and getting generic selectors messing with my component. This solves this kind of specificity problem on custom implementations of the menu
