### PR TITLE
Adds JSCS configuration file.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,6 @@
+{
+    "preset": "google",
+    "validateLineBreaks": "LF",
+    "validateIndentation": 2,
+    "excludeFiles": ["node_modules/**"]
+}


### PR DESCRIPTION
This change introduces a [JSCS](https://github.com/mdevils/node-jscs) configuration file which allows us to lint the style of any changes made to our scripts against the Google JavaScript style guide.

I’ve verified that app/main.js currently passes using the “google” preset. At this time, I think we should only use the file along with an editor plugin rather than introducing build-time tooling which may bloat the Gulpfile.  This seems fine for everyday use.

reviewer: @sindresorhus 
