### PR TITLE
Add `box-sizing` as an inherited value

### DIFF
--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -4,7 +4,13 @@
 *
 **/
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html {
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
This way, it should be easier to modify it's value for vendor components that don't handle `border-box` properly. For further details check: http://goo.gl/DGLMbk.
