### PR TITLE
Adding firefox styles to slider.

### DIFF
--- a/material/lite/slider.css
+++ b/material/lite/slider.css
@@ -12,6 +12,10 @@ input[type="range"] {
   color: #F4B400;
 }
 
+input[type=range]::-moz-focus-outer {
+  border: 0;
+}
+
 input[type="range"]::-webkit-slider-runnable-track {
   margin-left: -0.3rem;
   margin-right: -0.3rem;
@@ -30,6 +34,7 @@ input[type="range"]:focus:not(:active)::-webkit-slider-runnable-track {
 
 input[type="range"]::-moz-range-track {
   background-color: inherit;
+  border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {


### PR DESCRIPTION
I'm adding FF styling to slider. There are 2 unresolved issues with FF implementation:

the slider gets inner focus ring when focused, which I cannot easily remove due to https://bugzilla.mozilla.org/show_bug.cgi?id=851777
the -moz-range-thumb pseudo-elements do not get animations in FF :( Other than that, it seems usable in FF.
