### PR TITLE
Edits in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('styles', function () {
 gulp.task('html', function () {
   var assets = $.useref.assets({searchPath: '{.tmp,app}'});
 
-  return gulp.src('app/**/*.html')
+  return gulp.src('app/**/*')
     .pipe(assets)
     // Concatenate And Minify JavaScript
     .pipe($.if('*.js', $.uglify({preserveComments: 'some'})))


### PR DESCRIPTION
Hi,

I noticed a few problems while playing around with the Google WSK. 

The first one occured, when I moved the folder, and tried to run "gulp images".
It threw an error because the cache couldn't be cleared because it was opened by another gulp task.
Clearing it manualy before regenerating it has fixed that.

The second one occured while running "gulp serve:dist". 
It didn't copied javascript files in the scripts folder, and generaly no files like xxx.zip ( = not "web-typical" file types") which were in a subdirectory.

I hope you could take a look at them.

Greetings, Florian
