### PR TITLE
Simplify server configuration - remove 'baseDir'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,9 +149,7 @@ gulp.task('serve', ['styles'], function () {
     // Note: this uses an unsigned certificate which on first access
     //       will present a certificate warning in the browser.
     // https: true,
-    server: {
-      baseDir: ['.tmp', 'app']
-    }
+    server: ['.tmp', 'app']
   });
 
   gulp.watch(['app/**/*.html'], reload);
@@ -168,10 +166,7 @@ gulp.task('serve:dist', ['default'], function () {
     // Note: this uses an unsigned certificate which on first access
     //       will present a certificate warning in the browser.
     // https: true,
-    server: {
-      baseDir: 'dist'
-    }
-
+    server: 'dist'
   });
 });
 


### PR DESCRIPTION
Projects that only use the `baseDir` option can safely promote it to being the value of `server`

``` js
server: {
  baseDir: "./app"
}
```

is exactly the same (to BrowserSync) as:

``` js
server: "./app"
```

This would not work should you wish to use any _other_ server options in the future - but for the current configuration, it does make the gulpfile that little bit cleaner.
