### PR TITLE
Output some error when require-dir tasks fails

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -186,4 +186,4 @@ gulp.task('pagespeed', pagespeed.bind(null, {
 }));
 
 // Load custom tasks from the `tasks` directory
-try { require('require-dir')('tasks'); } catch (err) {}
+try { require('require-dir')('tasks'); } catch (err) { console.error(err); }


### PR DESCRIPTION
It could be useful to see the results of the require tasks especially if there is an error.
