### PR TITLE
Adding of Ripple Span

### DIFF
--- a/material/lite/buttons.js
+++ b/material/lite/buttons.js
@@ -13,6 +13,12 @@
 
         var ripple = this.querySelector('.ripple');
 
+        if (ripple === null) {
+          ripple = document.createElement('span');
+          ripple.className = 'ripple';
+          this.appendChild(ripple);
+        }
+
         TweenLite.set(ripple, {x: x, y: y, scaleX: 0, scaleY: 0, opacity: 1});
 
         TweenLite.to(ripple, 1.5, {scaleX: 1, scaleY: 1, opacity: 0, ease: Expo.easeOut});


### PR DESCRIPTION
This change will allows you to apply a ripple effect to an element that doesn't contain a child with the class of ripple by default. If no ripple class if found it will inject a span into the element and uses that instead.
