### PR TITLE
Update gulp-imagemin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulp-csso": "^0.2.9",
     "gulp-flatten": "0.0.3",
     "gulp-if": "^1.2.1",
-    "gulp-imagemin": "^1.0.0",
+    "gulp-imagemin": "^1.1.0",
     "gulp-jshint": "^1.6.3",
     "gulp-load-plugins": "^0.7.0",
     "gulp-minify-html": "^0.1.5",


### PR DESCRIPTION
Might fix the `imagemin-gifsicle` installation issue.
