### PR TITLE
One ripple to rule them all.

### DIFF
--- a/app/styleguide/button/_button.scss
+++ b/app/styleguide/button/_button.scss
@@ -2,6 +2,7 @@
 @import "../palette/palette";
 @import "../shadow/shadow";
 @import "../animation/animation";
+@import "../ripple/ripple";
 
 // Default Button Colors
 $default-btn-bg-color: #fff;
@@ -18,8 +19,7 @@ $colored-btn-hover-bg-color: nth($primaryPalette, 8);
 $colored-btn-focus-color: nth($primaryPalette, 12);
 $colored-btn-active-bg-color: nth($primaryPalette, 13);
 
-// Ripple Color
-$ripple-bg-color: nth($paletteGrey, 10);
+// Ripple Color for colored buttons.
 $color-ripple-bg-color: white;
 
 // Disabled Button Colors
@@ -39,7 +39,7 @@ $disabled-btn-text-color: nth($disabledPalette, 5);
   @include typo-button();
   overflow     : hidden;
   @include shadow-z1();
-  will-change: box-shadow;
+  will-change: box-shadow, transform;
   transition: box-shadow 0.2s ease-out;
 }
 
@@ -47,27 +47,7 @@ $disabled-btn-text-color: nth($disabledPalette, 5);
   background: $colored-btn-bg-color;
   color     : $colored-btn-text-color;
 }
-
-.PaperButton-ripple {
-  background       : $ripple-bg-color;
-  border-radius    : 50%;
-  height           : 50px;
-  left             : 0;
-  opacity          : 0;
-  pointer-events   : none;
-  position         : absolute;
-  top              : 0;
-  transform        : translate(-50%, -50%);
-  width            : 50px;
-  overflow: hidden;
-}
-.PaperButton-ripple.is-animating {
-  transition        : transform 0.6s $animation-curve-linear-out-slow-in,
-                      width 0.6s $animation-curve-linear-out-slow-in,
-                      height 0.6s $animation-curve-linear-out-slow-in,
-                      opacity 0.6s $animation-curve-linear-out-slow-in;
-}
-.PaperButton--colored .PaperButton-ripple {
+.PaperButton--colored .Ripple {
   background: $color-ripple-bg-color;
 }
 .PaperButton[disabled] {
@@ -98,4 +78,14 @@ $disabled-btn-text-color: nth($disabledPalette, 5);
 }
 .PaperButton--colored:active {
   background-color: $colored-btn-active-bg-color;
+}
+.PaperButton .PaperButton-rippleContainer {
+  display: block;
+  height: 100%;
+  left: 0px;
+  position: absolute;
+  top: 0px;
+  width: 100%;
+  z-index: 0;
+  overflow: hidden;
 }

--- a/app/styleguide/button/button.js
+++ b/app/styleguide/button/button.js
@@ -1,118 +1,14 @@
 'use strict';
 
-function PaperButton(el) {
-  var buttonElement = el;
-  var rippleElement = buttonElement.querySelector('.PaperButton-ripple');
-  var frameCount = 0;
-  var isSafari = /constructor/i.test(window.HTMLElement);
-  var rippleSize;
-  var x;
-  var y;
-
-  if (rippleElement) {
-    var bound = buttonElement.getBoundingClientRect();
-    rippleSize = Math.max(bound.width, bound.height) * 2;
-
-    rippleElement.style.width = rippleSize + 'px';
-    rippleElement.style.height = rippleSize + 'px';
-  }
-
-  buttonElement.addEventListener('click', this.onClickHandler.bind(this));
-
-  this.getFrameCount = function() {
-    return frameCount;
-  };
-
-  this.setFrameCount = function(fC) {
-    frameCount = fC;
-  };
-
-  this.getRippleElement = function() {
-    return rippleElement;
-  };
-
-  this.setRippleXY = function(newX, newY) {
-    x = newX;
-    y = newY;
-  };
-
-  this.setRippleStyles = function(start) {
-    if (rippleElement !== null) {
-      var transformString;
-      var scale;
-      var size;
-
-      if (start) {
-        scale = 'scale(0.0001, 0.0001)';
-        size = '1px';
-      } else {
-        scale = 'scale(1, 1)';
-        size = rippleSize + 'px';
-      }
-
-      transformString = 'translate(-50%, -50%) ' +
-        'translate(' + x + 'px, ' + y + 'px)';
-
-      // Safari unfortunately needs special handling, due to a bug with child
-      // elements not clipping at parent borders for certain transforms. We use
-      // the less performant alternative of changing width and height to work
-      // around the issue.
-      if (isSafari) {
-        rippleElement.style.height = size;
-        rippleElement.style.width = size;
-      } else {
-        transformString += scale;
-      }
-
-      rippleElement.style.webkitTransform = transformString;
-      rippleElement.style.msTransform = transformString;
-      rippleElement.style.transform = transformString;
-
-      if (start) {
-        rippleElement.style.opacity = '0.4';
-        rippleElement.classList.remove('is-animating');
-      } else {
-        rippleElement.style.opacity = '0';
-        rippleElement.classList.add('is-animating');
-      }
-    }
-  };
-
-  this.animFrameHandler = function() {
-    if (frameCount-- > 0) {
-      window.requestAnimFrame(this.animFrameHandler.bind(this));
-    } else {
-      this.setRippleStyles(false);
-    }
-  };
-}
-
-PaperButton.prototype.onClickHandler = function(evt) {
-  var frameCount = this.getFrameCount();
-  if (frameCount > 0) {
-    return;
-  }
-
-  this.setFrameCount(1);
-  var bound = evt.currentTarget.getBoundingClientRect();
-  var x;
-  var y;
-  // Check if we are handling a keyboard click
-  if (evt.clientX === 0 && evt.clientY === 0) {
-    x = Math.round(bound.width / 2);
-    y = Math.round(bound.height / 2);
-  } else {
-    x = Math.round(evt.clientX - bound.left);
-    y = Math.round(evt.clientY - bound.top);
-  }
-  this.setRippleXY(x, y);
-  this.setRippleStyles(true);
-  window.requestAnimFrame(this.animFrameHandler.bind(this));
-};
-
 window.addEventListener('load', function() {
-  var buttonElements = document.querySelectorAll('.PaperButton');
-  for (var i = 0; i < buttonElements.length; i++) {
-    new PaperButton(buttonElements[i]);
+  var buttomElementsWithRipples =
+      document.querySelectorAll('.PaperButton.RippleEffect');
+  for (var i = 0; i < buttomElementsWithRipples.length; i++) {
+    var rippleContainer = document.createElement('span');
+    rippleContainer.classList.add('PaperButton-rippleContainer');
+    var ripple = document.createElement('span');
+    ripple.classList.add('Ripple');
+    rippleContainer.appendChild(ripple);
+    buttomElementsWithRipples[i].appendChild(rippleContainer);
   }
 });

--- a/app/styleguide/button/demo.html
+++ b/app/styleguide/button/demo.html
@@ -19,7 +19,7 @@
 
     <h2>With Ripples</h2>
 
-    <button class="PaperButton">Button<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton RippleEffect">Button</button>
 
     <h2>.paper-button .colored</h2>
 
@@ -27,14 +27,15 @@
 
     <h2>With Ripples</h2>
 
-    <button class="PaperButton PaperButton--colored">Button<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton PaperButton--colored RippleEffect">Button</button>
 
     <h2>Disabled</h2>
 
-    <button class="PaperButton" disabled>Button<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton RippleEffect" disabled>Button</button>
   </div>
 
-    <script src="button.js"></script>
+    <script src="../button/button.js"></script>
+    <script src="../ripple/ripple.js"></script>
     <script src="../third_party/rAF.js"></script>
   </body>
 </html>

--- a/app/styleguide/checkbox/_checkbox.scss
+++ b/app/styleguide/checkbox/_checkbox.scss
@@ -1,13 +1,12 @@
 @import "../palette/palette";
 @import "../animation/animation";
+@import "../ripple/ripple";
 
 $circleSize: 40px;
 $checkboxSize: 16px;
 
 $borderColor: nth($secondaryPalette, 8);
 $checkboxColor: nth($primaryPalette, 6);
-$checkedFocusColor: rgba($checkboxColor, 0.26);
-$focusColor: rgba(nth($secondaryPalette, 6), 0.12);
 
 .Checkbox {
   border: 2px solid $borderColor;
@@ -21,13 +20,14 @@ $focusColor: rgba(nth($secondaryPalette, 6), 0.12);
   @include material-animation-default();
   z-index:1;
   box-sizing: border-box;
+  pointer-events: none;
   top: ($circleSize - $checkboxSize) / 2;
   left: ($circleSize - $checkboxSize) / 2;
 }
 
 .Checkbox-label {
   cursor: pointer;
-  font-size: 12pt;
+  font-size: 16px;
   display: block;
   overflow: hidden;
   //padding-top: ($circleSize / 2);
@@ -45,26 +45,21 @@ $focusColor: rgba(nth($secondaryPalette, 6), 0.12);
   transform: rotate(-45deg) scaleY(0.5);
 }
 
-.Checkbox-focusCircle {
-  background-color:$focusColor;
+.Checkbox-rippleContainer {
   border-radius: 50%;
   display: block;
   height: $circleSize;
   left: 0px;
-  opacity: 0;
   position: absolute;
   top: 0px;
-  @include material-animation-default();
   width: $circleSize;
-  z-index:0;
+  z-index: 0;
+  overflow: hidden;
+  -webkit-mask-image: -webkit-radial-gradient(circle, white, black);
 }
 
-.Checkbox-focusCircle.Checkbox-isChecked {
-  background-color: $checkedFocusColor;
-}
-
-.Checkbox-focusCircle.Checkbox-isFocused {
-  opacity: 1;
+.Checkbox-rippleContainer .Ripple {
+  background: $checkboxColor;
 }
 
 input[type='checkbox'].Checkbox {

--- a/app/styleguide/checkbox/checkbox.js
+++ b/app/styleguide/checkbox/checkbox.js
@@ -1,6 +1,6 @@
-function Checkbox(l) {
-  'use strict';
+'use strict';
 
+function Checkbox(l) {
   var labelElement = l;
   var checkboxElement = document.getElementById(
     labelElement.getAttribute('for'));
@@ -8,28 +8,24 @@ function Checkbox(l) {
 
   // Add additional elements
   var fakeCheckbox = document.createElement('span');
-  fakeCheckbox.className = 'Checkbox';
+  fakeCheckbox.classList.add('Checkbox');
   fakeCheckbox.tabIndex = 0;
-  var focusCircle = document.createElement('span');
-  focusCircle.className = 'Checkbox-focusCircle';
+  if (checkboxElement.classList.contains('RippleEffect')) {
+    checkboxElement.classList.add('RippleEffect--recentering');
+    var rippleContainer = document.createElement('span');
+    rippleContainer.classList.add('Checkbox-rippleContainer');
+    rippleContainer.classList.add('RippleEffect');
+    rippleContainer.classList.add('RippleEffect--recentering');
+    var ripple = document.createElement('span');
+    ripple.classList.add('Ripple');
 
-  labelElement.insertBefore(focusCircle,
-    labelElement.firstChild);
+    rippleContainer.appendChild(ripple);
+    labelElement.insertBefore(rippleContainer,
+      labelElement.firstChild);
+  }
   labelElement.insertBefore(fakeCheckbox,
      labelElement.firstChild);
 
-  fakeCheckbox.addEventListener('focus', function(evt) {
-    this.onFocusChange(evt, true);
-  }.bind(this));
-  fakeCheckbox.addEventListener('blur', function(evt) {
-    this.onFocusChange(evt, false);
-  }.bind(this));
-  labelElement.addEventListener('focus', function(evt) {
-    this.onFocusChange(evt);
-  }.bind(this));
-  labelElement.addEventListener('blur', function(evt) {
-    this.onFocusChange(evt);
-  }.bind(this));
   fakeCheckbox.addEventListener('click', function(evt) {
     this.onCheckChange(evt);
   }.bind(this));
@@ -52,42 +48,30 @@ function Checkbox(l) {
     return fakeCheckbox;
   };
 
-  this.getFocusCircleElement = function() {
-    return focusCircle;
+  this.getRippleElement = function() {
+    return rippleContainer;
   };
 }
 
-Checkbox.prototype.onFocusChange = function(evt, isFocused) {
-  'use strict';
-  var focusCircle = this.getFocusCircleElement();
-  if (isFocused) {
-    focusCircle.classList.add('Checkbox-isFocused');
-  } else {
-    focusCircle.classList.remove('Checkbox-isFocused');
-  }
-};
-
 Checkbox.prototype.onCheckChange = function(evt) {
-  'use strict';
   evt.preventDefault();
   evt.stopPropagation();
 
   var checkboxElement = this.getCheckboxElement();
   var fakeCheckbox = this.getFakeCheckboxElement();
-  var focusCircle = this.getFocusCircleElement();
+  var rippleContainer = this.getRippleElement();
 
   checkboxElement.checked = !checkboxElement.checked;
   if (checkboxElement.checked) {
     fakeCheckbox.classList.add('Checkbox-isChecked');
-    focusCircle.classList.add('Checkbox-isChecked');
+    rippleContainer.classList.add('Checkbox-isChecked');
   } else {
     fakeCheckbox.classList.remove('Checkbox-isChecked');
-    focusCircle.classList.remove('Checkbox-isChecked');
+    rippleContainer.classList.remove('Checkbox-isChecked');
   }
 };
 
 Checkbox.prototype.onKeyEvent = function(evt) {
-  'use strict';
   var SPACE_KEY = 32;
 
   if (evt.keyCode === SPACE_KEY) {
@@ -97,8 +81,6 @@ Checkbox.prototype.onKeyEvent = function(evt) {
 };
 
 window.addEventListener('load', function() {
-  'use strict';
-
   var labels =  document.getElementsByTagName('label');
   for (var i = 0; i < labels.length; i++) {
     new Checkbox(labels[i]);

--- a/app/styleguide/checkbox/demo.html
+++ b/app/styleguide/checkbox/demo.html
@@ -15,20 +15,22 @@
 
   <div class="preview-block">
 
-  <input type="checkbox" id="checkbox-1" class="Checkbox" />
+  <input type="checkbox" id="checkbox-1" class="Checkbox RippleEffect" />
   <label class="Checkbox-label" for="checkbox-1">Check me out</label>
 
-  <input type="checkbox" id="checkbox-2" class="Checkbox" />
+  <input type="checkbox" id="checkbox-2" class="Checkbox RippleEffect" />
   <label class="Checkbox-label" for="checkbox-2">I'm just a Material girl in a Material world</label>
 
-  <input type="checkbox" id="checkbox-3" class="Checkbox" />
+  <input type="checkbox" id="checkbox-3" class="Checkbox RippleEffect" />
   <label class="Checkbox-label" for="checkbox-3">But I work in all browsers</label>
 
-  <input type="checkbox" id="checkbox-4" class="Checkbox" />
+  <input type="checkbox" id="checkbox-4" class="Checkbox RippleEffect" />
   <label class="Checkbox-label" for="checkbox-4">Try using checkboxes</label>
 
   </div>
 
     <script src="checkbox.js"></script>
+    <script src="../third_party/rAF.js"></script>
+    <script src="../ripple/ripple.js"></script>
   </body>
 </html>

--- a/app/styleguide/fab/_fab.scss
+++ b/app/styleguide/fab/_fab.scss
@@ -39,3 +39,12 @@ $fabFontSize: 24px;
 .PaperFab--colored:active {
   background-color: $fabActiveBackgroundColor
 }
+
+.PaperFab--colored .Ripple {
+  background: $color-ripple-bg-color;
+}
+
+.PaperFab .PaperButton-rippleContainer {
+  border-radius: 50%;
+  -webkit-mask-image: -webkit-radial-gradient(circle, white, black);
+}

--- a/app/styleguide/fab/demo.html
+++ b/app/styleguide/fab/demo.html
@@ -20,7 +20,7 @@
 
     <h2>With Ripples</h2>
 
-    <button class="PaperButton PaperFab">♥<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton PaperFab RippleEffect">♥</button>
 
     <h2>.paper-button .colored</h2>
 
@@ -28,14 +28,15 @@
 
     <h2>With Ripples</h2>
 
-    <button class="PaperButton PaperFab PaperFab--colored">♥<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton PaperFab PaperFab--colored RippleEffect">♥</button>
 
     <h2>Disabled</h2>
 
-    <button class="PaperButton PaperFab" disabled>♥<div class="PaperButton-ripple"></div></button>
+    <button class="PaperButton PaperFab RippleEffect" disabled>♥</button>
   </div>
 
     <script src="../button/button.js"></script>
+    <script src="../ripple/ripple.js"></script>
     <script src="../third_party/rAF.js"></script>
   </body>
 </html>

--- a/app/styleguide/radio/_radio.scss
+++ b/app/styleguide/radio/_radio.scss
@@ -1,9 +1,9 @@
 @import "../palette/palette";
 @import "../animation/animation";
+@import "../ripple/ripple";
 
 $borderColor: nth($secondaryPalette, 8);
 $radioColor: nth($primaryPalette, 6);
-$radioRippleColor: rgba($radioColor, 0.26);
 
 $labelHeight: 20px;
 $radioButtonSize: 14px;
@@ -20,6 +20,8 @@ $rippleSize: 42px;
 
 .RadioButton-label {
   position: relative;
+
+  font-size: 16px;
 
   display: inline-block;
 
@@ -59,7 +61,8 @@ $rippleSize: 42px;
   width: $radioButtonSize;
   height: $radioButtonSize;
 
-  @include material-animation-default();
+  @include material-animation-default(0.28s);
+  transition-property: transform;
   transform: scale3d(0, 0, 0);
 
   border-radius: 50%;
@@ -70,7 +73,7 @@ $rippleSize: 42px;
   transform: scale3d(1, 1, 1);
 }
 
-.RadioButton-ripple {
+.RadioButton-rippleContainer {
   position: absolute;
   z-index: 2;
   top: -((($rippleSize - $radioButtonSize) / 2) - $topOffset);
@@ -79,14 +82,12 @@ $rippleSize: 42px;
   box-sizing: border-box;
   width: $rippleSize;
   height: $rippleSize;
-
-  @include material-animation-default();
-
-  opacity: 0;
   border-radius: 50%;
-  background: $radioRippleColor;
+
+  overflow: hidden;
+  -webkit-mask-image: -webkit-radial-gradient(circle, white, black);
 }
 
-.RadioButton-ripple.RadioButton-isRippling {
-  opacity: 1;
+.RadioButton-rippleContainer .Ripple {
+  background: $radioColor;
 }

--- a/app/styleguide/radio/demo.html
+++ b/app/styleguide/radio/demo.html
@@ -17,21 +17,23 @@
 
   <section class="preview-block">
     <label class="RadioButton-label">
-      <input type="radio" class="RadioButton" name="wifi[]" value="1" checked />
+      <input type="radio" class="RadioButton RippleEffect" name="wifi[]" value="1" checked />
       Always
     </label>
 
     <label class="RadioButton-label">
-      <input type="radio" class="RadioButton" name="wifi[]" value="2" />
+      <input type="radio" class="RadioButton RippleEffect" name="wifi[]" value="2" />
       Only when plugged in
     </label>
 
     <label class="RadioButton-label">
-      <input type="radio" class="RadioButton" name="wifi[]" value="3" />
+      <input type="radio" class="RadioButton RippleEffect" name="wifi[]" value="3" />
       Never
     </label>
   </section>
 
     <script src="radio.js"></script>
+    <script src="../third_party/rAF.js"></script>
+    <script src="../ripple/ripple.js"></script>
   </body>
 </html>

--- a/app/styleguide/radio/radio.js
+++ b/app/styleguide/radio/radio.js
@@ -7,32 +7,22 @@ function RadioButton(btnElement, labelElement) {
   var innerCircle = document.createElement('span');
   innerCircle.classList.add('RadioButton-innerCircle');
 
-  var ripple = document.createElement('span');
-  ripple.classList.add('RadioButton-ripple');
-
   labelElement.insertBefore(outerCircle, btnElement);
   labelElement.appendChild(innerCircle);
-  labelElement.appendChild(ripple);
 
-  this.onClick = function(evt) {
-    if (ripple === null) {
-      return;
-    }
+  if (btnElement.classList.contains('RippleEffect')) {
+    btnElement.classList.add('RippleEffect--recentering');
+    var rippleContainer = document.createElement('span');
+    rippleContainer.classList.add('RadioButton-rippleContainer');
+    rippleContainer.classList.add('RippleEffect');
+    rippleContainer.classList.add('RippleEffect--recentering');
 
-    ripple.classList.add('RadioButton-isRippling');
-  };
+    var ripple = document.createElement('span');
+    ripple.classList.add('Ripple');
 
-  this.onEndOfRippleTransition = function() {
-    ripple.classList.remove('RadioButton-isRippling');
-  };
-
-  labelElement.addEventListener('click', this.onClick.bind(this));
-  ripple.addEventListener('webkitTransitionEnd',
-      this.onEndOfRippleTransition.bind(this));
-  ripple.addEventListener('oTransitionEnd',
-      this.onEndOfRippleTransition.bind(this));
-  ripple.addEventListener('transitionEnd',
-      this.onEndOfRippleTransition.bind(this));
+    rippleContainer.appendChild(ripple);
+    labelElement.appendChild(rippleContainer);
+  }
 }
 
 window.addEventListener('load', function() {

--- a/app/styleguide/ripple/_ripple.scss
+++ b/app/styleguide/ripple/_ripple.scss
@@ -1,0 +1,26 @@
+@import "../palette/palette";
+@import "../animation/animation";
+
+// Ripple Color
+$ripple-bg-color: nth($paletteGrey, 10);
+
+.Ripple {
+  background       : $ripple-bg-color;
+  border-radius    : 50%;
+  height           : 50px;
+  left             : 0;
+  opacity          : 0;
+  pointer-events   : none;
+  position         : absolute;
+  top              : 0;
+  transform        : translate(-50%, -50%);
+  width            : 50px;
+  overflow: hidden;
+}
+
+.Ripple.is-animating {
+  transition        : transform 0.6s $animation-curve-linear-out-slow-in,
+                      width 0.6s $animation-curve-linear-out-slow-in,
+                      height 0.6s $animation-curve-linear-out-slow-in,
+                      opacity 0.6s $animation-curve-linear-out-slow-in;
+}

--- a/app/styleguide/ripple/ripple.js
+++ b/app/styleguide/ripple/ripple.js
@@ -1,0 +1,113 @@
+'use strict';
+
+function RippleOwner(el, recentering) {
+  var parentElement = el;
+  var rippleElement = parentElement.querySelector('.Ripple');
+  var frameCount = 0;
+  var rippleSize;
+  var x;
+  var y;
+
+  if (rippleElement) {
+    var bound = parentElement.getBoundingClientRect();
+    rippleSize = Math.max(bound.width, bound.height) * 2;
+
+    rippleElement.style.width = rippleSize + 'px';
+    rippleElement.style.height = rippleSize + 'px';
+  }
+
+  parentElement.addEventListener('click', this.onClickHandler.bind(this));
+
+  this.getFrameCount = function() {
+    return frameCount;
+  };
+
+  this.setFrameCount = function(fC) {
+    frameCount = fC;
+  };
+
+  this.getRippleElement = function() {
+    return rippleElement;
+  };
+
+  this.setRippleXY = function(newX, newY) {
+    x = newX;
+    y = newY;
+  };
+
+  this.setRippleStyles = function(start) {
+    if (rippleElement !== null) {
+      var transformString;
+      var scale;
+      var size;
+      var offset = 'translate(' + x + 'px, ' + y + 'px)';
+
+      if (start) {
+        scale = 'scale(0.0001, 0.0001)';
+        size = '1px';
+      } else {
+        scale = 'scale(1, 1)';
+        size = rippleSize + 'px';
+        if (recentering) {
+          offset = 'translate(' + bound.width / 2 + 'px, ' +
+            bound.height / 2 + 'px)';
+        }
+      }
+
+      transformString = 'translate(-50%, -50%) ' + offset + scale;
+
+      rippleElement.style.webkitTransform = transformString;
+      rippleElement.style.msTransform = transformString;
+      rippleElement.style.transform = transformString;
+
+      if (start) {
+        rippleElement.style.opacity = '0.4';
+        rippleElement.classList.remove('is-animating');
+      } else {
+        rippleElement.style.opacity = '0';
+        rippleElement.classList.add('is-animating');
+      }
+    }
+  };
+
+  this.animFrameHandler = function() {
+    if (frameCount-- > 0) {
+      window.requestAnimFrame(this.animFrameHandler.bind(this));
+    } else {
+      this.setRippleStyles(false);
+    }
+  };
+}
+
+RippleOwner.prototype.onClickHandler = function(evt) {
+  var frameCount = this.getFrameCount();
+  if (frameCount > 0) {
+    return;
+  }
+
+  this.setFrameCount(1);
+  var bound = evt.currentTarget.getBoundingClientRect();
+  var x;
+  var y;
+  // Check if we are handling a keyboard click
+  if (evt.clientX === 0 && evt.clientY === 0) {
+    x = Math.round(bound.width / 2);
+    y = Math.round(bound.height / 2);
+  } else {
+    x = Math.round(evt.clientX - bound.left);
+    y = Math.round(evt.clientY - bound.top);
+  }
+  this.setRippleXY(x, y);
+  this.setRippleStyles(true);
+  window.requestAnimFrame(this.animFrameHandler.bind(this));
+};
+
+window.addEventListener('load', function() {
+  var rippleElements = document.querySelectorAll('.RippleEffect');
+  for (var i = 0; i < rippleElements.length; i++) {
+    var rippleElement = rippleElements[i];
+    var recentering =
+        rippleElement.classList.contains('RippleEffect--recentering');
+    new RippleOwner(rippleElement, recentering);
+  }
+});


### PR DESCRIPTION
Refactors buttons, FABs, radio buttons and checkboxes to all use the same ripples.
Also simplifies adding ripples to components by specifying the RippleEffect class (which is now required for checkboxes and radio buttons as well, which will otherwise not have ripples).
