### PR TITLE
Include slider.js in concatenated js

### DIFF
--- a/app/styleguide/slider/demo.html
+++ b/app/styleguide/slider/demo.html
@@ -19,6 +19,10 @@
     <p><input type="range" min="0" max="100" value="0" tabindex="0" disabled/></p>
     <p><input type="range" min="0" max="100" value="10" tabindex="0" disabled/></p>
   </div>
+  <!-- build:js scripts/main.min.js -->
   <script src="slider.js"></script>
+  <!-- endbuild -->
+  <script src="../../scripts/main.min.js"></script>
+
   </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,7 @@ gulp.task('styles', function() {
 
 // Scan Your HTML For Assets & Optimize Them
 gulp.task('html', function() {
-  var assets = $.useref.assets({searchPath: '{.tmp,app}'});
+  var assets = $.useref.assets({searchPath: "{.tmp,app,app/styleguide/slider}"});
 
   return gulp.src('app/**/*.html')
     .pipe(assets)


### PR DESCRIPTION
In the `material-sprint` branch, none of the JS loads properly under the `gulp dist` build. (A `main.min.js` is created, but it's essentially empty.)

I don't know what I'm doing with gulp so I don't know how to fix this properly, but hopefully this hack (which fixes the slider demo only) will provide enough information for someone to fix it properly!
