### PR TITLE
Keep dist/.git while removing everything else.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,7 @@ gulp.task('html', function () {
 });
 
 // Clean Output Directory
-gulp.task('clean', del.bind(null, ['.tmp', 'dist/*', '!dist/.git']));
+gulp.task('clean', del.bind(null, ['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
 
 // Watch Files For Changes & Reload
 gulp.task('serve', ['styles'], function () {


### PR DESCRIPTION
That way it is possible to have `dist` folder under revision control
for things like hosting on Heroku and push-to-deploy in general.

Thanks @gauntface for a hint on `del` package.
