### PR TITLE
Avoid big quote icon covered the .quote__content

### DIFF
--- a/app/styles/components/_modules/_quote.scss
+++ b/app/styles/components/_modules/_quote.scss
@@ -39,6 +39,7 @@
       top: 225px;
       left: -210px;
       font-size: 540px;
+      z-index: -1;
     }
   }
 }


### PR DESCRIPTION
now, the quote icon covered the quote content.
![image](https://cloud.githubusercontent.com/assets/1808835/5048815/3bcdf27e-6c5b-11e4-9baa-106bba6d493e.png)
