### PR TITLE
Added W3C Webapp Manifest

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,8 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Web Starter Kit</title>
 
-    <!-- Add to homescreen for Chrome on Android -->
+    <!-- Add to homescreen -->
+    <link rel="manifest" href="manifest.json">
+
+    <!-- Fallback to homescreen for Chrome <39 on Android -->
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="Web Starter Kit">
     <link rel="icon" sizes="192x192" href="images/touch/chrome-touch-icon-192x192.png">
 
     <!-- Add to homescreen for Safari on iOS -->
@@ -20,7 +24,7 @@
     <!-- Tile icon for Win8 (144x144 + tile color) -->
     <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
     <meta name="msapplication-TileColor" content="#3372DF">
-    
+
     <meta name="theme-color" content="#3372DF">
 
     <!-- SEO: If your mobile URL is different from the desktop URL, add a canonical link to the desktop page https://developers.google.com/webmasters/smartphone-sites/feature-phones -->

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Web Starter Kit",
+  "short_name": "WSK",
+  "icons": [{
+        "src": "images/touch/icon-128x128.png",
+        "sizes": "128x128"
+      }, {
+        "src": "images/touch/apple-touch-icon.png",
+        "sizes": "152x152"
+      }, {
+        "src": "images/touch/ms-touch-icon-144x144-precomposed.png",
+        "sizes": "144x144"
+      }, {
+        "src": "images/touch/chrome-touch-icon-192x192.png",
+        "sizes": "192x192"
+      }],
+  "start_url": "/index.html?homescreen=1",
+  "display": "standalone"
+}


### PR DESCRIPTION
The webapp manifest is now supported in Chrome 39 and will be the best practice way to add a webapp to a devices home screen from now on.
https://w3c.github.io/manifest/

Fixes #495
