### PR TITLE
Remove .sass-cache folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-.sass-cache
 dist
 .tmp


### PR DESCRIPTION
Using LibSass instead of Ruby Sass removed the `.sass-cache` folder.
