### PR TITLE
Fixed font-smoothing for Firefox.

### DIFF
--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -13,7 +13,7 @@
 html,
 body,
 button {
-  -moz-osx-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
 }


### PR DESCRIPTION
Implementation of font-smoothing in _global.scss is incorrect for Firefox.

`-moz-osx-font-smoothing: antialiased` should be `-moz-osx-font-smoothing: grayscale`
See: https://bugzilla.mozilla.org/show_bug.cgi?id=857142#c83

![webstarterkit-firefox-current](https://cloud.githubusercontent.com/assets/958819/5377057/022a2150-807e-11e4-9b98-2f3a88db6934.png)
![webstarterkit-firefox-improved](https://cloud.githubusercontent.com/assets/958819/5377059/063356c2-807e-11e4-82a2-11e05484f71a.png)
