### PR TITLE
Correct R, G and B color

### DIFF
--- a/app/styles/components/_palette.scss
+++ b/app/styles/components/_palette.scss
@@ -15,8 +15,8 @@ $colorGrayLighter: rgba($colorBlack, .12);
 
 /* ==========  Color Palettes  ========== */
 
-$paletteRed: #fde0dc #f9bdbb #f69988 #f36c60 #e84e40 #e51c23 #dd191d
-           #d01716 #c41411 #b0120a #ff7997 #ff5177 #ff2d6f #e00032;
+$paletteRed: #ffebee #ffcdd2 #ef9a9a #e57373 #ef5350 #f44336 #e53935
+           #d32f2f #c62828 #b71c1c #ff8a80 #ff5252 #ff1744 #d50000;
 
 $palettePink:   #fce4ec #f8bbd0 #f48fb1 #f06292 #ec407a #e91e63 #d81b60
               #c2185b #ad1457 #880e4f #ff80ab #ff4081 #f50057 #c51162;
@@ -31,8 +31,8 @@ $paletteDeepPurple: #673ab7 #ede7f6 #d1c4e9 #b39ddb #9575cd #7e57c2 #673ab7
 $paletteIndigo: #e8eaf6 #c5cae9 #9fa8da #7986cb #5c6bc0 #3f51b5 #3949ab
               #303f9f #283593 #1a237e #8c9eff #536dfe #3d5afe #304ffe;
 
-$paletteBlue: #e7e9fd #d0d9ff #afbfff #91a7ff #738ffe #5677fc #4e6cef
-            #455ede #3b50ce #2a36b1 #a6baff #6889ff #4d73ff #4d69ff;
+$paletteBlue: #e3f2fd #bbdefb #90caf9 #64b5f6 #42a5f5 #2196f3 #1e88e5
+            #1976d2 #1565c0 #0d47a1 #82b1ff #448aff #2979ff #2962ff;
 
 $paletteLightBlue: #e1f5fe #b3e5fc #81d4fa #4fc3f7 #29b6f6 #03a9f4 #039be5
                  #0288d1 #0277bd #01579b #80d8ff #40c4ff #00b0ff #0091ea;
@@ -43,8 +43,8 @@ $paletteCyan: #e0f7fa #b2ebf2 #80deea #4dd0e1 #26c6da #00bcd4 #00acc1
 $paletteTeal: #e0f2f1 #b2dfdb #80cbc4 #4db6ac #26a69a #009688 #00897b
             #00796b #00695c #004d40 #a7ffeb #64ffda #1de9b6 #00bfa5;
 
-$paletteGreen: #d0f8ce #a3e9a4 #72d572 #42bd41 #2baf2b #259b24 #0a8f08
-             #0a7e07 #056f00 #0d5302 #a2f78d #5af158 #14e715 #12c700;
+$paletteGreen: #e8f5e9 #c8e6c9 #a5d6a7 #81c784 #66bb6a #4caf50 #43a047
+             #388e3c #2e7d32 #1b5e20 #b9f6ca #69f0ae #00e676 #00c853;
 
 $paletteLightGreen: #f1f8e9 #dcedc8 #c5e1a5 #aed581 #9ccc65 #8bc34a #7cb342
                   #689f38 #558b2f #33691e #ccff90 #b2ff59 #76ff03 #64dd17;


### PR DESCRIPTION
Red, green, blue color is not match with current [Google Material Color](http://www.google.com/design/spec/style/color.html#color-color-palette) site e.g.

````
// Google Red
red50 = #ffebee
red100 = #ffcdd2
red200 = #ef9a9a
...
````

compare to

````
red50 = #fde0dc
red100 = #f9bdbb
red200 = #f69988
...
````

This happen only R, G, B but other color is seem to be fine.