### PR TITLE
Added ability to listen to upgrades via ComponentHandler

### DIFF
--- a/app/styleguide/animation/animation.js
+++ b/app/styleguide/animation/animation.js
@@ -75,14 +75,10 @@ MaterialAnimation.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialAnimation,
-    classAsString: 'MaterialAnimation',
-    cssClass: 'demo-js-clickable-area'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialAnimation,
+  classAsString: 'MaterialAnimation',
+  cssClass: 'demo-js-clickable-area'
 });

--- a/app/styleguide/button/button.js
+++ b/app/styleguide/button/button.js
@@ -74,14 +74,10 @@ MaterialButton.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialButton,
-    classAsString: 'MaterialButton',
-    cssClass: 'wsk-js-button'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialButton,
+  classAsString: 'MaterialButton',
+  cssClass: 'wsk-js-button'
 });

--- a/app/styleguide/checkbox/checkbox.js
+++ b/app/styleguide/checkbox/checkbox.js
@@ -230,14 +230,10 @@ MaterialCheckbox.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialCheckbox,
-    classAsString: 'MaterialCheckbox',
-    cssClass: 'wsk-js-checkbox'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialCheckbox,
+  classAsString: 'MaterialCheckbox',
+  cssClass: 'wsk-js-checkbox'
 });

--- a/app/styleguide/column-layout/column-layout.js
+++ b/app/styleguide/column-layout/column-layout.js
@@ -59,14 +59,10 @@ MaterialColumnLayout.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialColumnLayout,
-    classAsString: 'MaterialColumnLayout',
-    cssClass: 'wsk-column-layout'
-  });
+//The component registers itself. It can assume componentHandler is available
+//in the global scope.
+componentHandler.register({
+  constructor: MaterialColumnLayout,
+  classAsString: 'MaterialColumnLayout',
+  cssClass: 'wsk-column-layout'
 });

--- a/app/styleguide/item/item.js
+++ b/app/styleguide/item/item.js
@@ -55,14 +55,10 @@ MaterialItem.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialItem,
-    classAsString: 'MaterialItem',
-    cssClass: 'wsk-js-ripple-effect'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialItem,
+  classAsString: 'MaterialItem',
+  cssClass: 'wsk-js-ripple-effect'
 });

--- a/app/styleguide/layout/layout.js
+++ b/app/styleguide/layout/layout.js
@@ -208,14 +208,10 @@ MaterialLayout.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialLayout,
-    classAsString: 'MaterialLayout',
-    cssClass: 'wsk-js-layout'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialLayout,
+  classAsString: 'MaterialLayout',
+  cssClass: 'wsk-js-layout'
 });

--- a/app/styleguide/radio/radio.js
+++ b/app/styleguide/radio/radio.js
@@ -208,14 +208,10 @@ MaterialRadio.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialRadio,
-    classAsString: 'MaterialRadio',
-    cssClass: 'wsk-js-radio'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialRadio,
+  classAsString: 'MaterialRadio',
+  cssClass: 'wsk-js-radio'
 });

--- a/app/styleguide/ripple/ripple.js
+++ b/app/styleguide/ripple/ripple.js
@@ -181,14 +181,10 @@ MaterialRipple.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialRipple,
-    classAsString: 'MaterialRipple',
-    cssClass: 'wsk-js-ripple-effect'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialRipple,
+  classAsString: 'MaterialRipple',
+  cssClass: 'wsk-js-ripple-effect'
 });

--- a/app/styleguide/slider/slider.js
+++ b/app/styleguide/slider/slider.js
@@ -155,14 +155,10 @@ MaterialSlider.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialSlider,
-    classAsString: 'MaterialSlider',
-    cssClass: 'wsk-js-slider'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialSlider,
+  classAsString: 'MaterialSlider',
+  cssClass: 'wsk-js-slider'
 });

--- a/app/styleguide/textfield/textfield.js
+++ b/app/styleguide/textfield/textfield.js
@@ -135,14 +135,10 @@ MaterialTextfield.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialTextfield,
-    classAsString: 'MaterialTextfield',
-    cssClass: 'wsk-js-textfield'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialTextfield,
+  classAsString: 'MaterialTextfield',
+  cssClass: 'wsk-js-textfield'
 });

--- a/app/styleguide/tooltip/tooltip.js
+++ b/app/styleguide/tooltip/tooltip.js
@@ -81,14 +81,10 @@ MaterialTooltip.prototype.init = function() {
 };
 
 
-window.addEventListener('load', function() {
-  'use strict';
-
-  // On document ready, the component registers itself. It can assume
-  // componentHandler is available in the global scope.
-  componentHandler.register({
-    constructor: MaterialTooltip,
-    classAsString: 'MaterialTooltip',
-    cssClass: 'wsk-tooltip'
-  });
+// The component registers itself. It can assume componentHandler is available
+// in the global scope.
+componentHandler.register({
+  constructor: MaterialTooltip,
+  classAsString: 'MaterialTooltip',
+  cssClass: 'wsk-tooltip'
 });

--- a/app/styleguide/wskComponentHandler.js
+++ b/app/styleguide/wskComponentHandler.js
@@ -1,11 +1,4 @@
 /**
- * @license
- * Copyright 2014 Web Starter Kit.
- * https://github.com/google/web-starter-kit
- *
- * License: MIT
- * Author: Jason Mayes
- *
  * A component handler interface using the revealing module design pattern.
  * More details on this pattern design here:
  * https://github.com/jasonmayes/wsk-component-design-pattern


### PR DESCRIPTION
Added extra function to register callback functions on a component class
basis such that you can be alerted when a DOM element gets upgraded.
This is useful in a situation such as this:

1) User decides to use wskCheckbox.
2) When the checkbox is clicked the user wishes to update some parent
node's class (to change the visual style of a table row for example).
3) All they need to do now is register an event listener using
componentHandler.registerUpgradedCallback(JSClass, callback) so that
their callback is called every time any DOM element is upgraded to type
JSClass. The callback function takes 1 parameter which is the
HTMLElement that was upgraded.
4) This saves the user much time and efficiency as they don't need to
"Monitor the DOM" for changes. It also allows them to be notified when
things are added after page load too.