### PR TITLE
Fix a .jscsrc rule

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
   "preset": "google",
+  "disallowSpacesInAnonymousFunctionExpression": null,
   "validateLineBreaks": "LF",
   "validateIndentation": 2,
   "excludeFiles": ["node_modules/**"]


### PR DESCRIPTION
Allow a space between the function keyword and the round opening
brace.

See: https://github.com/google/web-starter-kit/pull/594#issuecomment-69624013.