### PR TITLE
Moved the "use strict" statement inside function

### DIFF
--- a/app/styleguide/third_party/rAF.js
+++ b/app/styleguide/third_party/rAF.js
@@ -1,8 +1,7 @@
-'use strict';
-
 // From: http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
 // shim layer with setTimeout fallback
 window.requestAnimFrame = (function() {
+  'use strict';
   return window.requestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
     window.mozRequestAnimationFrame ||


### PR DESCRIPTION
A simple update moving used strict declaration inside the function to limit scope as this can cause chaos with 3rd party systems that are not written strictly.