### PR TITLE
Fixes gulp-changed plugin's usage in the gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('styles', function () {
     'app/styles/**/*.css',
     'app/styles/components/components.scss'
   ])
-    .pipe($.changed('styles', {extension: '.scss'}))
+    .pipe($.changed('.tmp/styles', {extension: '.css'}))
     .pipe($.sass({
       precision: 10,
       onError: console.error.bind(console, 'Sass error:')


### PR DESCRIPTION
Fixes wrong arguments in $.changed() which should be passing only changed .scss files
for complilation to .css.
First argument was 'styles' which is a non-existant folder since the destination forlder
is '.tmp/styles'. The second argument should have the suffices of the destination folder files,
which is '.css' and not '.scss'