### PR TITLE
Add "Cutting the Mustard" test

### DIFF
--- a/app/styleguide/wskComponentHandler.js
+++ b/app/styleguide/wskComponentHandler.js
@@ -156,10 +156,9 @@ window.addEventListener('load', function() {
    * components requiring JavaScript.
    */
   if ('classList' in document.createElement('div') && 'querySelector' in document && 'addEventListener' in window && Array.prototype.forEach) {
-    document.documentElement.className += 'wsk-js';
+    document.documentElement.classList.add('wsk-js');
     componentHandler.upgradeAllRegistered();
   } else {
-    componentHandler.register = function () { /*noop*/ };
-    componentHandler.upgradeElement = function () { /*noop*/ };
+    componentHandler.upgradeElement = componentHandler.register = function () { };
   }
 });

--- a/app/styleguide/wskComponentHandler.js
+++ b/app/styleguide/wskComponentHandler.js
@@ -161,6 +161,5 @@ window.addEventListener('load', function() {
   } else {
     componentHandler.register = function () { /*noop*/ };
     componentHandler.upgradeElement = function () { /*noop*/ };
-    componentHandler.upgradeElement = function () { /*noop*/ };
   }
 });

--- a/app/styleguide/wskComponentHandler.js
+++ b/app/styleguide/wskComponentHandler.js
@@ -11,7 +11,6 @@ var componentHandler = (function() {
   var registeredComponents_ = [];
   var createdComponents_ = [];
 
-
   /**
    * Searches registered components for a class we are interested in using.
    * Optionally replaces a match with passed object if specified.
@@ -151,5 +150,17 @@ var componentHandler = (function() {
 window.addEventListener('load', function() {
   'use strict';
 
-  componentHandler.upgradeAllRegistered();
+  /**
+   * Performs a "Cutting the mustard" test. If the browser supports the features
+   * tested, adds a wsk-js class to the <html> element. It then upgrades all WSK
+   * components requiring JavaScript.
+   */
+  if ('classList' in document.createElement('div') && 'querySelector' in document && 'addEventListener' in window && Array.prototype.forEach) {
+    document.documentElement.className += 'wsk-js';
+    componentHandler.upgradeAllRegistered();
+  } else {
+    componentHandler.register = function () { /*noop*/ };
+    componentHandler.upgradeElement = function () { /*noop*/ };
+    componentHandler.upgradeElement = function () { /*noop*/ };
+  }
 });


### PR DESCRIPTION
We should define a CTM (Cutting the Mustard) test is, so WSK JavaScript components know what baseline functionality can safely be relied on. If a browser does not support our baseline, component handler logic defaults to noop.

This change will test for the presence of ClassList, querySelector, addEventListener and `Array.prototype.forEach`. In addition to upgrading components correctly, this change will add a `wsk-js` class to the document `<html>`. 

I've tested this out in evergreen browsers as well as IE9, 10 and 11. 

reviewers: @jasonmayes @sindresorhus @sgomes 

Prior art:

* http://responsivenews.co.uk/post/18948466399/cutting-the-mustard
* https://github.com/Financial-Times/ft-origami/issues/88
* http://codepen.io/atelierbram/pen/lepzJ