### PR TITLE
Improve readability of the autoprefixer browser list

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,15 +29,15 @@ var pagespeed = require('psi');
 var reload = browserSync.reload;
 
 var AUTOPREFIXER_BROWSERS = [
-  'ie >= 10',
-  'ie_mob >= 10',
-  'ff >= 30',
-  'chrome >= 34',
-  'safari >= 7',
-  'opera >= 23',
-  'ios >= 7',
-  'android >= 4.4',
-  'bb >= 10'
+  'Explorer >= 10',
+  'ExplorerMobile >= 10',
+  'Firefox >= 30',
+  'Chrome >= 34',
+  'Safari >= 7',
+  'Opera >= 23',
+  'iOS >= 7',
+  'Android >= 4.4',
+  'BlackBerry >= 10'
 ];
 
 // Lint JavaScript


### PR DESCRIPTION
Similarly how you give names to variables: `pagespeed`, `browserSync`, `runSequence` instead of `psi`, `bs`, `run`.