### PR TITLE
Fixes #579, filtering gulp.src base directories for image glob

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,13 +49,14 @@ gulp.task('jshint', function () {
     .pipe($.if(!browserSync.active, $.jshint.reporter('fail')));
 });
 
-// Optimize Images
+// Optimize Images Recursively (All Files)
 gulp.task('images', function () {
   return gulp.src('app/images/**/*')
-    .pipe($.cache($.imagemin({
+    .pipe($.if($.if.isFile,$.cache($.imagemin({
       progressive: true,
       interlaced: true
-    })))
+     }))
+    .on('error', function(err){ console.log(err); this.end; })))
     .pipe(gulp.dest('dist/images'))
     .pipe($.size({title: 'images'}));
 });


### PR DESCRIPTION
This fixed #579.  Somewhat recently, the gulp-cache repository made some changes that made sending files not easily managed by gulp-cache a much simpler pill to swallow.  That's definitely changing (they're fixing problems, to be clear... I'll offer a patch to clean up their error handling, at least) and short of a simple gulp.src nodir+follow option, using the included gulp-if plugin to drop out of the file stream the base directories makes the gulp file work super smoothly.  Hope it helps!