### PR TITLE
Fixes #579, Dup of #636 in master, allows filtering gulp.src base directories for image glob

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,13 +41,14 @@ gulp.task('jshint', function() {
     .pipe($.if(!browserSync.active, $.jshint.reporter('fail')));
 });
 
-// Optimize Images
-gulp.task('images', function() {
+// Optimize Images Recursively (All Files)
+gulp.task('images', function () {
   return gulp.src('app/images/**/*')
-    .pipe($.cache($.imagemin({
+    .pipe($.if($.if.isFile,$.cache($.imagemin({
       progressive: true,
       interlaced: true
-    })))
+     }))
+    .on('error', function(err){ console.log(err); this.end; })))
     .pipe(gulp.dest('dist/images'))
     .pipe($.size({title: 'images'}));
 });


### PR DESCRIPTION
Take a gander at #636 for a few more details. This fix might work in a lot of branches, frankly, but the material-sprint branch is where I first ran into issues.  Hopefully it helps!  (And this fixes #579.)