### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+sudo: false
 language: node_js
 node_js:
+  - iojs
+  - '0.12'
   - '0.10'
+matrix:
+  allow_failures:
+    - node_js: iojs


### PR DESCRIPTION
Use container-based infrastructure
Add iojs and 0.12 to node_js
Allow iojs to fail because it does not have `libsass` bindings