### PR TITLE
Add tasks for static assets revisioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-html": "0.1.5",
     "gulp-replace": "^0.5.0",
+    "gulp-rev": "^3.0.1",
+    "gulp-rev-replace": "^0.4.0",
     "gulp-sass": "^1.2.0",
     "gulp-size": "^1.0.0",
     "gulp-sourcemaps": "^1.3.0",


### PR DESCRIPTION
Static assets revisioning in production built, in order to flush client cache whenever files change.