### PR TITLE
Build pipeline refresh

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -64,7 +64,7 @@
       <p>Read how to <a href="https://developers.google.com/web/starter-kit">Get Started</a> or check out the <a href="styleguide.html">Style Guide</a>.</p>
     </main>
 
-    <!-- build:js scripts/main.min.js -->
+    <!-- build:js(app/) ../../scripts/main.min.js -->
     <script src="scripts/main.js"></script>
     <!-- endbuild -->
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -67,7 +67,7 @@
       }
 
       // updatefound is fired if service-worker.js changes.
-      registration.onupdatefound = function() {
+      registration.onupdatefound = function () {
         // updatefound is also fired the very first time the SW is installed,
         // and there's no need to prompt for a reload at that point.
         // So check here to see if the page is already controlled,
@@ -77,7 +77,7 @@
           // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event
           var installingWorker = registration.installing;
 
-          installingWorker.onstatechange = function() {
+          installingWorker.onstatechange = function () {
             switch (installingWorker.state) {
               case 'installed':
                 // At this point, the old content will have been purged and the
@@ -92,7 +92,7 @@
           };
         }
       };
-    }).catch(function(e) {
+    }).catch(function (e) {
       console.error('Error during service worker registration:', e);
     });
   }

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,7 +1,7 @@
 /*!
  *
  *  Web Starter Kit
- *  Copyright 2014 Google Inc. All rights reserved.
+ *  Copyright 2015 Google Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/app/styleguide.html
+++ b/app/styleguide.html
@@ -8,7 +8,9 @@
     <meta itemprop="name" content="Visual Style Guide — Web Starter Kit">
     <meta itemprop="description" content="Visual style guide used by this site.">
 
-    <link rel="stylesheet" href="styles/components.css">
+    <!-- build:css(app/) styles/components/components.css -->
+    <link rel="stylesheet" href="styles/components/components.css">
+    <!-- endbuild -->
 
     <title>Visual Style Guide — Web Starter Kit</title>
     <style>

--- a/app/styles/components/_components/_icons.scss
+++ b/app/styles/components/_components/_icons.scss
@@ -1,11 +1,11 @@
 @font-face {
   font-family: icons;
-  src: url(../images/icons/icons.eot);
-  src: url(../images/icons/icons.eot?#iefix) format('embedded-opentype'),
-    url(../images/icons/icons.woff2) format('woff2'),
-    url(../images/icons/icons.woff) format('woff'),
-    url(../images/icons/icons.ttf) format('truetype'),
-    url(../images/icons/icons.svg?#icons) format('svg');
+  src: url(../../images/icons/icons.eot);
+  src: url(../../images/icons/icons.eot?#iefix) format('embedded-opentype'),
+    url(../../images/icons/icons.woff2) format('woff2'),
+    url(../../images/icons/icons.woff) format('woff'),
+    url(../../images/icons/icons.ttf) format('truetype'),
+    url(../../images/icons/icons.svg?#icons) format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,7 +160,7 @@ gulp.task('html', function () {
 gulp.task('clean', del.bind(null, ['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
 
 // Watch files for changes & reload
-gulp.task('serve', ['styles'], function() {
+gulp.task('serve', ['styles'], function () {
   browserSync({
     notify: false,
     // Customize the BrowserSync console logging prefix
@@ -179,7 +179,7 @@ gulp.task('serve', ['styles'], function() {
 });
 
 // Build and serve the output from the dist build
-gulp.task('serve:dist', ['default'], function() {
+gulp.task('serve:dist', ['default'], function () {
   browserSync({
     notify: false,
     logPrefix: 'WSK',
@@ -193,7 +193,7 @@ gulp.task('serve:dist', ['default'], function() {
 });
 
 // Build production files, the default task
-gulp.task('default', ['clean'], function(cb) {
+gulp.task('default', ['clean'], function (cb) {
   runSequence(
     'styles',
     ['jshint', 'html', 'scripts', 'images', 'fonts', 'copy'],
@@ -218,7 +218,7 @@ gulp.task('pagespeed', function (cb) {
 // Generate a service worker file that will provide offline functionality for
 // local resources. This should only be done for the 'dist' directory, to allow
 // live reload to work as expected when serving from the 'app' directory.
-gulp.task('generate-service-worker', function(callback) {
+gulp.task('generate-service-worker', function (callback) {
   var rootDir = 'dist';
 
   swPrecache({
@@ -244,12 +244,12 @@ gulp.task('generate-service-worker', function(callback) {
     ],
     // Translates a static file path to the relative URL that it's served from.
     stripPrefix: path.join(rootDir, path.sep)
-  }, function(error, serviceWorkerFileContents) {
+  }, function (error, serviceWorkerFileContents) {
     if (error) {
       return callback(error);
     }
     fs.writeFile(path.join(rootDir, 'service-worker.js'),
-      serviceWorkerFileContents, function(error) {
+      serviceWorkerFileContents, function (error) {
       if (error) {
         return callback(error);
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-cache": "0.2.2",
     "gulp-changed": "^1.0.0",
+    "gulp-concat": "^2.5.2",
     "gulp-csso": "^1.0.0",
     "gulp-flatten": "0.0.4",
     "gulp-if": "^1.2.1",


### PR DESCRIPTION
This is my first attempt at backporting the changes to our build setup from the material-sprint branch to master. 

Things we need to verify still work for everyone on all platforms:

* `gulp`
* `gulp serve`
* `gulp serve`, edit Sass, see a refresh with updated content

I'm aware of one issue at the moment which is icons for the styleguide not being copied over and will address.