### PR TITLE
Fix JSCS warning in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,7 +157,9 @@ gulp.task('html', function () {
 });
 
 // Clean output directory
-gulp.task('clean', del.bind(null, ['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
+gulp.task('clean', function (cb) {
+  del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}, cb);
+});
 
 // Watch files for changes & reload
 gulp.task('serve', ['styles'], function () {


### PR DESCRIPTION
> JSCS requires all lines to be at most 80 characters long by default

##### Before

```js
// Clean output directory
gulp.task('clean', del.bind(null, ['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
```

##### After

```js
// Clean output directory
gulp.task('clean', function (cb) {
  del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}, cb);
});
```

Also makes the "clean" task more readable.

I think that `.bind(...)` is more "cryptic" than a plain old anonymous function which by the way is already used in other places within the same `gulpfile.js`

Ref #645