### PR TITLE
Adding type to the manifest.json file so app install banners work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .tmp
+app.yaml

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,16 +3,20 @@
   "short_name": "WSK",
   "icons": [{
         "src": "images/touch/icon-128x128.png",
-        "sizes": "128x128"
+        "sizes": "128x128",
+        "type": "image/png"
       }, {
         "src": "images/touch/apple-touch-icon.png",
-        "sizes": "152x152"
+        "sizes": "152x152",
+        "type": "image/png"
       }, {
         "src": "images/touch/ms-touch-icon-144x144-precomposed.png",
-        "sizes": "144x144"
+        "sizes": "144x144",
+        "type": "image/png"
       }, {
         "src": "images/touch/chrome-touch-icon-192x192.png",
-        "sizes": "192x192"
+        "sizes": "192x192",
+        "type": "image/png"
       }],
   "start_url": "/index.html?homescreen=1",
   "display": "standalone"


### PR DESCRIPTION
There is an issue where the app install banner won't be allowed unless the type of the icon images is defined, this PR adds them in.

I added app.yaml to .gitignore since app install banners don't work with localhost and I had to push to appengine to test this stuff out - we don't want that ending up in the repo.