### PR TITLE
Update to components with font-face so you can see headings in style …

### DIFF
--- a/app/styles/components/_components/_guides-list.scss
+++ b/app/styles/components/_components/_guides-list.scss
@@ -39,7 +39,7 @@
 
   .primary-content {
     @include medium {
-      flex: 1;
+      
     }
   }
 

--- a/app/styles/components/_components/_typography.scss
+++ b/app/styles/components/_components/_typography.scss
@@ -4,6 +4,79 @@
 *
 **/
 
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 300;
+  src: url(/fonts/RobotoCondensed-Light.eot);
+  src: url(/fonts/RobotoCondensed-Light.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-Light.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-Light.woff) format('woff'),
+    url(/fonts/RobotoCondensed-Light.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-Light.svg?#icons) format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  src: url(/fonts/RobotoCondensed-Regular.eot);
+  src: url(/fonts/RobotoCondensed-Regular.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-Regular.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-Regular.woff) format('woff'),
+    url(/fonts/RobotoCondensed-Regular.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-Regular.svg?#icons) format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 700;
+  src: url(/fonts/RobotoCondensed-Bold.eot);
+  src: url(/fonts/RobotoCondensed-Bold.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-Bold.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-Bold.woff) format('woff'),
+    url(/fonts/RobotoCondensed-Bold.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-Bold.svg?#icons) format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: italic;
+  font-weight: 300;
+  src: url(/fonts/RobotoCondensed-LightItalic.eot);
+  src: url(/fonts/RobotoCondensed-LightItalic.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-LightItalic.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-LightItalic.woff) format('woff'),
+    url(/fonts/RobotoCondensed-LightItalic.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-LightItalic.svg?#icons) format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: italic;
+  font-weight: 400;
+  src: url(/fonts/RobotoCondensed-Italic.eot);
+  src: url(/fonts/RobotoCondensed-Italic.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-Italic.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-Italic.woff) format('woff'),
+    url(/fonts/RobotoCondensed-Italic.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-Italic.svg?#icons) format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto Condensed';
+  font-style: italic;
+  font-weight: 700;
+  src: url(/fonts/RobotoCondensed-BoldItalic.eot);
+  src: url(/fonts/RobotoCondensed-BoldItalic.eot?#iefix) format('embedded-opentype'),
+    url(/fonts/RobotoCondensed-BoldItalic.woff2) format('woff2'),
+    url(/fonts/RobotoCondensed-BoldItalic.woff) format('woff'),
+    url(/fonts/RobotoCondensed-BoldItalic.ttf) format('truetype'),
+    url(/fonts/RobotoCondensed-BoldItalic.svg?#icons) format('svg');
+}
+
 // Just normalizing text
 // Recommend using padding instead of margin
 h1, h2, h3, h4, h5, p {


### PR DESCRIPTION
Update to typography components with font-face so you can see headings in style guide for IE9+.

Removal of flex for .primary-content broken in IE11.