### PR TITLE
Fix: gulp-sass stops working

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,10 @@ gulp.task('styles', function () {
     .pipe($.sourcemaps.init())
     .pipe($.sass({
       precision: 10
-    }).on('error', $.sass.logError))
+    }).on('error', function() {
+      $.sass.logError.apply(null, Array.prototype.slice.call(arguments));
+      this.emit('end');
+    }))
     .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
     .pipe(gulp.dest('.tmp'))
     // Concatenate and minify styles


### PR DESCRIPTION
In case an error occurs while compiling sass files, it will display it on console, however it will stops compiling further updates and modification. The problem can be solved by having `emit('end')` to the error callback. 

Since gulp-sass offers its own error handler (`sass.logError`), it would make life easier for all if they add the fix to the handler.