### PR TITLE
babel was renamed to babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "apache-server-configs": "^2.7.1",
-    "babel": "^5.4.7",
+    "babel-core": "^5.4.7",
     "browser-sync": "^2.6.4",
     "del": "^1.1.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Same fix in generator-gulp-webapp: https://github.com/yeoman/generator-gulp-webapp/commit/31348ff1acc393af507a7b8a192d767cf9737021.

Fixes #726 