### PR TITLE
Fix CSS sourcemap generation

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -91,7 +91,7 @@ gulp.task('styles', () => {
 
   // For best performance, don't add Sass partials to `gulp.src`
   return gulp.src([
-    'app/**/*.scss',
+    'app/styles/**/*.scss',
     'app/styles/**/*.css'
   ])
     .pipe($.changed('.tmp/styles', {extension: '.css'}))
@@ -100,11 +100,12 @@ gulp.task('styles', () => {
       precision: 10
     }).on('error', $.sass.logError))
     .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
-    .pipe(gulp.dest('.tmp'))
+    .pipe($.sourcemaps.write())
+    .pipe(gulp.dest('.tmp/styles'))
     // Concatenate and minify styles
     .pipe($.if('*.css', $.minifyCss()))
-    .pipe($.sourcemaps.write())
-    .pipe(gulp.dest('dist'))
+    .pipe($.sourcemaps.write('.'))
+    .pipe(gulp.dest('dist/styles'))
     .pipe($.size({title: 'styles'}));
 });
 


### PR DESCRIPTION
Generating an intermediary sourcemaps for the files in `.tmp`
There seem to be a sourcemaps issue with sass when the sourcemaps ends up having a folder prefix. This happens because the globs in `gulp.src` didn't have the same base folder so fixed that as well.