### PR TITLE
Adding optional ES2015 support via Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  // Remove the line below to enable ES2015 support.
+  "only": "gulpfile.babel.js",
+  "retainLines": true
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,8 +1,5 @@
 {
   "preset": "google",
   "disallowSpacesInAnonymousFunctionExpression": null,
-  "excludeFiles": [
-    "node_modules/**",
-    "gulpfile.babel.js"
-  ]
+  "esnext": true
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ If you would prefer not to use any of our tooling, delete the following files fr
 
 If you are interested in adding in different tooling workflows to your gulpfile.js, we recommend looking at the official Gulp [recipes](https://github.com/gulpjs/gulp/tree/master/docs/recipes) directory which includes a comprehensive list of guides.
 
+## ES2015 Support
+
+Web Starter Kit has optional ES2015 support using [Babel](https://babeljs.io/).
+To enable ES2015 support remove the line `"only": "gulpfile.babel.js",` in the [.babelrc](.babelrc) file.
+ES2015 source code will be automatically transpiled to ES5 for wide browser support.
+
 ## Extras
 
 Optional additions, such as web server configurations, can be found at [WSK Extras

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -16,7 +16,7 @@
  *  limitations under the License
  *
  */
-(function () {
+(function() {
   'use strict';
 
   // Check to make sure service workers are supported in the current browser,
@@ -38,7 +38,7 @@
       }
 
       // updatefound is fired if service-worker.js changes.
-      registration.onupdatefound = function () {
+      registration.onupdatefound = function() {
         // updatefound is also fired the very first time the SW is installed,
         // and there's no need to prompt for a reload at that point.
         // So check here to see if the page is already controlled,
@@ -48,7 +48,7 @@
           // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event
           var installingWorker = registration.installing;
 
-          installingWorker.onstatechange = function () {
+          installingWorker.onstatechange = function() {
             switch (installingWorker.state) {
               case 'installed':
                 // At this point, the old content will have been purged and the
@@ -64,7 +64,7 @@
           };
         }
       };
-    }).catch(function (e) {
+    }).catch(function(e) {
       console.error('Error during service worker registration:', e);
     });
   }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,8 @@
  *
  */
 
+'use strict';
+
 // This gulpfile makes use of new JavaScript features.
 // Babel handles this without us having to do anything. It just works.
 // You can read more about the new JavaScript features here:
@@ -109,20 +111,28 @@ gulp.task('styles', () => {
     .pipe($.size({title: 'styles'}));
 });
 
-// Concatenate and minify JavaScript
+// Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.
+// to enables ES2015 support remove the line `"only": "gulpfile.babel.js",` in the
+// `.babelrc` file.
 gulp.task('scripts', () =>
-  gulp.src([
-    // Note: Since we are not using useref in the scripts build pipeline,
-    //       you need to explicitly list your scripts here in the right order
-    //       to be correctly concatenated
-    './app/scripts/main.js'
-    // Other scripts
-  ])
-    .pipe($.concat('main.min.js'))
-    .pipe($.uglify({preserveComments: 'some'}))
-    // Output files
-    .pipe(gulp.dest('dist/scripts'))
-    .pipe($.size({title: 'scripts'}))
+    gulp.src([
+      // Note: Since we are not using useref in the scripts build pipeline,
+      //       you need to explicitly list your scripts here in the right order
+      //       to be correctly concatenated
+      './app/scripts/main.js'
+      // Other scripts
+    ])
+      .pipe($.newer('.tmp/scripts'))
+      .pipe($.sourcemaps.init())
+      .pipe($.babel())
+      .pipe($.sourcemaps.write())
+      .pipe(gulp.dest('.tmp/scripts'))
+      .pipe($.concat('main.min.js'))
+      .pipe($.uglify({preserveComments: 'some'}))
+      // Output files
+      .pipe($.sourcemaps.write('.'))
+      .pipe(gulp.dest('dist/scripts'))
+      .pipe($.size({title: 'scripts'}))
 );
 
 // Scan your HTML for assets & optimize them
@@ -159,10 +169,11 @@ gulp.task('html', () => {
 });
 
 // Clean output directory
-gulp.task('clean', cb => del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}, cb));
+gulp.task('clean', cb => del(['.tmp', 'dist/*', '!dist/.git'], {dot: true},
+  cb));
 
 // Watch files for changes & reload
-gulp.task('serve', ['styles'], () => {
+gulp.task('serve', ['scripts', 'styles'], () => {
   browserSync({
     notify: false,
     // Customize the BrowserSync console logging prefix
@@ -176,7 +187,7 @@ gulp.task('serve', ['styles'], () => {
 
   gulp.watch(['app/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.{scss,css}'], ['styles', reload]);
-  gulp.watch(['app/scripts/**/*.js'], ['jshint']);
+  gulp.watch(['app/scripts/**/*.js'], ['jshint', 'scripts']);
   gulp.watch(['app/images/**/*'], reload);
 });
 
@@ -208,7 +219,7 @@ gulp.task('default', ['clean'], cb =>
 gulp.task('pagespeed', cb =>
   // Update the below URL to the public URL of your site
   pagespeed('example.com', {
-    strategy: 'mobile',
+    strategy: 'mobile'
     // By default we use the PageSpeed Insights free (no API key) tier.
     // Use a Google Developer API key if you have one: http://goo.gl/RkN0vE
     // key: 'YOUR_API_KEY'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "del": "^1.1.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.0.0",
+    "gulp-babel": "^5.2.0",
     "gulp-cache": "0.2.2",
     "gulp-concat": "^2.5.2",
     "gulp-flatten": "0.0.4",


### PR DESCRIPTION
Currently the way to opt-in is to rename a new gulp task. let me know if you think of better ways.

We could also simply enable it by default since this workflow also works with ES<=5 files.

@addyosmani PTAL