### PR TITLE
Making sure gulp-newer does not filter out SCSS files.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -94,7 +94,7 @@ gulp.task('styles', () => {
     'app/styles/**/*.scss',
     'app/styles/**/*.css'
   ])
-    .pipe($.newer({dest: '.tmp/styles', ext: '.css'}))
+    .pipe($.newer('.tmp/styles'))
     .pipe($.sourcemaps.init())
     .pipe($.sass({
       precision: 10


### PR DESCRIPTION
Fixes #326 
@addyosmani PTAL