### PR TITLE
Feature: enable scroll syncing when browsers are at different breakpoints...

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -165,8 +165,10 @@ gulp.task('clean', cb => del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}, cb))
 gulp.task('serve', ['styles'], () => {
   browserSync({
     notify: false,
-    // Customize the BrowserSync console logging prefix
+    // Customize the Browsersync console logging prefix
     logPrefix: 'WSK',
+    // Allow scroll syncing across breakpoints
+    scrollElementMapping: ['main', '.mdl-layout'],
     // Run as an https by uncommenting 'https: true'
     // Note: this uses an unsigned certificate which on first access
     //       will present a certificate warning in the browser.
@@ -185,12 +187,13 @@ gulp.task('serve:dist', ['default'], () =>
   browserSync({
     notify: false,
     logPrefix: 'WSK',
+    // Allow scroll syncing across breakpoints
+    scrollElementMapping: ['main', '.mdl-layout'],
     // Run as an https by uncommenting 'https: true'
     // Note: this uses an unsigned certificate which on first access
     //       will present a certificate warning in the browser.
     // https: true,
-    server: 'dist',
-    baseDir: 'dist'
+    server: 'dist'
   })
 );
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "apache-server-configs": "^2.7.1",
     "babel-core": "^5.4.7",
-    "browser-sync": "^2.6.4",
+    "browser-sync": "^2.9.0",
     "del": "^1.1.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.0.0",


### PR DESCRIPTION
I recently noticed problem with scroll sync on this project.

The combination of `window` never scrolling at all (you scroll other elements) and a fixed header on smaller screens meant there was literally zero scroll syncing :(

This prompted me to implement a feature that's been often requested elsewhere - the ability to sync the scroll position of any element in addition to window. So far so good, so it seemed - until I realised that at different breakpoints, the element that is actually scrolling in this project switches between `main` and `.mdl-layout`.

This renders the usual event-capturing techniques useless as a mobile broadcaster may report a scroll position from 1 element, but desktop receivers don't know what to do with the data (as they are scrolling a separate element)

This has lead to what I believe to both a unique and amazing feature of Browsersync. Given `x` amount of elements, scroll position will be synced between them. Basically allows http://quick.as/996hpq2l