### PR TITLE
Remove unused gulp-flatten and gulp-replace plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gulp-minify-css": "^1.1.6",
     "gulp-minify-html": "0.1.5",
     "gulp-newer": "^0.5.1",
-    "gulp-replace": "^0.5.3",
     "gulp-sass": "^2.0.0",
     "gulp-size": "^1.0.0",
     "gulp-sourcemaps": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-cache": "0.2.2",
     "gulp-concat": "^2.5.2",
-    "gulp-flatten": "0.0.4",
     "gulp-if": "^1.2.1",
     "gulp-imagemin": "^2.0.0",
     "gulp-jshint": "^1.6.3",


### PR DESCRIPTION
Correct me if I'm wrong, but gulp-flatten and gulp-replace don't seem to be used anywhere in WSK. A git grep of the project seems to confirm.