### PR TITLE
Move script reloading to the JSHint watch task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -39,7 +39,6 @@ const reload = browserSync.reload;
 // Lint JavaScript
 gulp.task('jshint', () =>
   gulp.src('app/scripts/**/*.js')
-    .pipe(reload({stream: true, once: true}))
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
     .pipe($.if(!browserSync.active, $.jshint.reporter('fail')))
@@ -176,7 +175,7 @@ gulp.task('serve', ['styles'], () => {
 
   gulp.watch(['app/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.{scss,css}'], ['styles', reload]);
-  gulp.watch(['app/scripts/**/*.js'], ['jshint']);
+  gulp.watch(['app/scripts/**/*.js'], ['jshint', reload]);
   gulp.watch(['app/images/**/*'], reload);
 });
 


### PR DESCRIPTION
All other tasks separate their core functionality and browser reloading by placing the `reload` method in the watch task. Patterns aid readability / grokkability, so let's normalize this for JS.

It seems like the options `once` and `stream` aren't in the BrowserSync API docs anymore. Tests for them still exist in the BrowserSync repo, so not sure if they're being deprecated. This PR removes them either way. 

I'm not entirely sure if placing the `reload` logic in the JSHint task was solving a specific problem, but in my project these changes have been working well. 