### PR TITLE
Fix size reporting

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -105,9 +105,9 @@ gulp.task('styles', () => {
     .pipe(gulp.dest('.tmp/styles'))
     // Concatenate and minify styles
     .pipe($.if('*.css', $.minifyCss()))
+    .pipe($.size({title: 'styles'}))
     .pipe($.sourcemaps.write('.'))
-    .pipe(gulp.dest('dist/styles'))
-    .pipe($.size({title: 'styles'}));
+    .pipe(gulp.dest('dist/styles'));
 });
 
 // Concatenate and minify JavaScript. Optionally transpiles ES2015 code to ES5.
@@ -129,9 +129,9 @@ gulp.task('scripts', () =>
       .pipe($.concat('main.min.js'))
       .pipe($.uglify({preserveComments: 'some'}))
       // Output files
+      .pipe($.size({title: 'scripts'}))
       .pipe($.sourcemaps.write('.'))
       .pipe(gulp.dest('dist/scripts'))
-      .pipe($.size({title: 'scripts'}))
 );
 
 // Scan your HTML for assets & optimize them

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -163,8 +163,8 @@ gulp.task('html', () => {
     // Minify any HTML
     .pipe($.if('*.html', $.minifyHtml()))
     // Output files
-    .pipe(gulp.dest('dist'))
-    .pipe($.size({title: 'html'}));
+    .pipe($.if('*.html', $.size({title: 'html', showFiles: true})))
+    .pipe(gulp.dest('dist'));
 });
 
 // Clean output directory


### PR DESCRIPTION
Fixes https://github.com/google/web-starter-kit/issues/764

This gives us more useful size information. See the referenced issue and commit messages for more information.

I didn't touch the copy task, but wonder if we can improve that as well. `.htaccess` size isn't horribly useful when considering web performance, but I'm not sure what inferences we can make for the base directory glob for the majority of the userbase. Although it's not entirely a representation of bytes going over the wire, it could still be useful in relation to itself (does it go up, does it go down). Suggestions welcome.