### PR TITLE
Implements runtime SW caching for some CDN resources

### DIFF
--- a/app/scripts/sw/runtime-caching.js
+++ b/app/scripts/sw/runtime-caching.js
@@ -1,0 +1,34 @@
+/*!
+ *
+ *  Web Starter Kit
+ *  Copyright 2015 Google Inc. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ *
+ */
+
+/* jshint worker: true */
+// global.toolbox is defined in a different script, sw-toolbox.js, which is part of the
+// https://github.com/GoogleChrome/sw-toolbox project.
+// That sw-toolbox.js script must be executed first, so it needs to be listed before this in the
+// importScripts() call that the parent service worker makes.
+(function(global) {
+  'use strict';
+
+  // See https://github.com/GoogleChrome/sw-toolbox/blob/6e8242dc328d1f1cfba624269653724b26fa94f1/README.md#toolboxroutergeturlpattern-handler-options
+  // and https://github.com/GoogleChrome/sw-toolbox/blob/6e8242dc328d1f1cfba624269653724b26fa94f1/README.md#toolboxfastest
+  // for more details on how this handler is defined and what the toolbox.fastest strategy does.
+  global.toolbox.router.get('/(.*)', global.toolbox.fastest, {
+    origin: /\.(?:googleapis|gstatic)\.com$/
+  });
+})(self);

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -223,18 +223,29 @@ gulp.task('pagespeed', cb =>
   }, cb)
 );
 
+// Copy over the scripts that are used in importScripts as part of the generate-service-worker task.
+gulp.task('copy-sw-scripts', () => {
+  return gulp.src(['node_modules/sw-toolbox/sw-toolbox.js', 'app/scripts/sw/runtime-caching.js'])
+    .pipe(gulp.dest('dist/scripts/sw'));
+});
+
 // See http://www.html5rocks.com/en/tutorials/service-worker/introduction/ for
 // an in-depth explanation of what service workers are and why you should care.
 // Generate a service worker file that will provide offline functionality for
 // local resources. This should only be done for the 'dist' directory, to allow
 // live reload to work as expected when serving from the 'app' directory.
-gulp.task('generate-service-worker', () => {
+gulp.task('generate-service-worker', ['copy-sw-scripts'], () => {
   const rootDir = 'dist';
   const filepath = path.join(rootDir, 'service-worker.js');
 
   return swPrecache.write(filepath, {
     // Used to avoid cache conflicts when serving on localhost.
     cacheId: pkg.name || 'web-starter-kit',
+    // sw-toolbox.js needs to be listed first. It sets up methods used in runtime-caching.js.
+    importScripts: [
+      'scripts/sw/sw-toolbox.js',
+      'scripts/sw/runtime-caching.js'
+    ],
     staticFileGlobs: [
       // Add/remove glob patterns to match your directory setup.
       `${rootDir}/images/**/*`,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "psi": "^1.0.4",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.1",
-    "sw-precache": "^2.2.0"
+    "sw-precache": "^2.2.0",
+    "sw-toolbox": "^3.0.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
R: @addyosmani 

This adds in a new dependency on the `sw-toolbox` library, and uses its [`fastest`](https://github.com/GoogleChrome/sw-toolbox#toolboxfastest) strategy for handling runtime caching of resources served off hostnames ending in either "googleapis.com" or "gstatic.com".

One thing this doesn't do is [precache](https://github.com/GoogleChrome/sw-toolbox/#toolboxprecachearrayofurls) the resource URLs used in `index.html` that are served off of a CDN. One of those URLs is likely to be customized by developers (swapping out `indigo-pink` for a different theme) and the other is a shim CSS file that loads the underlying web font from a different URL,. Hardcoding them in a list to be precached wouldn't have the intended effect. In practice, this means that it's not until the second visit to a WSK site that the runtime caching will kick in and the CSS + font resources will be subsequently available offline.

Closes #769 