### PR TITLE
Upgrade gulp-useref version and gulp task to 3.0.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -129,10 +129,8 @@ gulp.task('scripts', () =>
 
 // Scan your HTML for assets & optimize them
 gulp.task('html', () => {
-  const assets = $.useref.assets({searchPath: '{.tmp,app}'});
-
   return gulp.src('app/**/*.html')
-    .pipe(assets)
+    .pipe($.useref({searchPath: '{.tmp,app}'}))
     // Remove any unused CSS
     // Note: If not using the Style Guide, you can delete it from
     //       the next line to only include styles your project uses.
@@ -150,8 +148,6 @@ gulp.task('html', () => {
     // Concatenate and minify styles
     // In case you are still using useref build blocks
     .pipe($.if('*.css', $.minifyCss()))
-    .pipe(assets.restore())
-    .pipe($.useref())
 
     // Minify any HTML
     .pipe($.if('*.html', $.minifyHtml()))

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",
     "gulp-uncss": "^1.0.0",
-    "gulp-useref": "^2.0.0",
+    "gulp-useref": "^3.0.0",
     "psi": "^1.0.4",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.1",


### PR DESCRIPTION
Upgrading the gulp-useref plugin to version 3.0. 

3.0 has a simpler API. It only uses one stream now for html and assets so it simplifies the gulp task quite a bit.