### PR TITLE
ignore dist/ only in the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
-dist
+dist/
 .tmp
 app.yaml


### PR DESCRIPTION
 This `dist` will ignore every `dist` directory in the repository not just ones in the root directory. 

I have a project where author is bundling external repos as he modified them I know this isn't the ideal setup but this was my case. so with `dist` in `.gitignore` I lost some of his bundled files under `some/directory/libs/jquery/dist` they weren't pushed to the repo.

modifying `dist` to `/dist` to ignore only `dist` in root directory fixs my problems http://stackoverflow.com/questions/15084780/gitignore-ignore-one-specific-directory-and-that-one-only