### PR TITLE
Updated the commands doc to explain SW differences

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,6 +41,17 @@ cache, you will need to reload the page after regenerating the site to pick up t
 `serve:dist` uses a different HTTP port than `serve`, which means that the service workers are
 kept isolated in different [scopes](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Registering_your_worker).
 
+## Difference Between `serve` & `serve:dist`
+
+It is important to note a difference between the `serve` and `serve:dist` tasks.
+
+* `serve` uses a no-op `service-worker.js` and cannot run offline.
+* `serve:dist` uses the `sw-precache`-generated output and can run offline.
+
+The `serve` task runs on port 3000 and `serve:dist` runs on port 3001.
+The main purpose is to ensure that different service workers will not impact each other's environment. 
+Using the `sw-precache`-generated output makes it very difficult to quickly test local changes which is not ideal for a development server environment.
+
 ## Performance Insights
 
 ```sh


### PR DESCRIPTION
This PR contains a new section in **docs/commands.md** which explains the difference between the `serve` and `serve:dist` tasks.

* `serve` uses a no-op `service-worker.js` and cannot run offline.
* `serve:dist` uses the `sw-precache`-generated output and can run offline.

resolves #770 