### PR TITLE
Cleanup unused code in gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -151,7 +151,7 @@ gulp.task('html', () => {
 });
 
 // Clean output directory
-gulp.task('clean', cb => del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
+gulp.task('clean', () => del(['.tmp', 'dist/*', '!dist/.git'], {dot: true}));
 
 // Watch files for changes & reload
 gulp.task('serve', ['scripts', 'styles'], () => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -24,7 +24,6 @@
 // You can read more about the new JavaScript features here:
 // https://babeljs.io/docs/learn-es2015/
 
-import fs from 'fs';
 import path from 'path';
 import gulp from 'gulp';
 import del from 'del';


### PR DESCRIPTION
1. Removes an unused callback in the clean task.
2. Removes an unused import (fs).