### PR TITLE
Prevent useref from outputting main.min.js (Closes #848)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -284,7 +284,7 @@
     </div>
 
     <script src="https://storage.googleapis.com/code.getmdl.io/1.0.6/material.min.js"></script>
-    <!-- build:js(app/) ../../scripts/main.min.js -->
+    <!-- build:js scripts/main.min.js -->
     <script src="scripts/main.js"></script>
     <!-- endbuild -->
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -129,6 +129,11 @@ gulp.task('scripts', () =>
 gulp.task('html', () => {
   return gulp.src('app/**/*.html')
     .pipe($.useref({searchPath: '{.tmp,app}'}))
+
+    // We use useref for changing the reference to main.js
+    // Drop its output because it's not the minified version
+    .pipe($.ignore.exclude('scripts/main.min.js'))
+
     // Remove any unused CSS
     .pipe($.if('*.css', $.uncss({
       html: [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-eslint": "^1.0.0",
     "gulp-htmlmin": "^1.3.0",
     "gulp-if": "^2.0.0",
+    "gulp-ignore": "^2.0.1",
     "gulp-imagemin": "^2.0.0",
     "gulp-load-plugins": "^1.0.0",
     "gulp-newer": "^1.0.0",


### PR DESCRIPTION
There appears to be an unintended side-effect caused by a `useref` reference in the markup. `useref` dutifully copies `scripts/main.js` into `../../scripts/main.min.js`(app context) which lands outside the project folder. It does not touch any other files in `scripts` outside the project folder. However, it does override `main.min.js` should it exist already. This is destructive so I've provided a fix.

We are relying on `useref` to swap the script reference to the minified version during the `html` build task. The fix drops the version of main.min.js produced by the `html` task because we solely rely on the `script` task to produce the minified version.

cc @addyosmani 