### PR TITLE
Remove registration.update()

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -37,13 +37,6 @@
       (window.location.protocol === 'https:' || isLocalhost)) {
     navigator.serviceWorker.register('service-worker.js')
     .then(function(registration) {
-      // Check to see if there's an updated version of service-worker.js with
-      // new files to cache:
-      // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-update-method
-      if (typeof registration.update === 'function') {
-        registration.update();
-      }
-
       // updatefound is fired if service-worker.js changes.
       registration.onupdatefound = function() {
         // updatefound is also fired the very first time the SW is installed,


### PR DESCRIPTION
R: @addyosmani _et al._

Fixes #860, which was an incompatibility with Firefox's service worker implementation due to an immediate, unneeded call to `registration.update()`.