### PR TITLE
remove usage of the gulp-uncss plugin

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -179,7 +179,7 @@ gulp.task('serve', ['scripts', 'styles'], () => {
 
   gulp.watch(['app/**/*.html'], reload);
   gulp.watch(['app/styles/**/*.{scss,css}'], ['styles', reload]);
-  gulp.watch(['app/scripts/**/*.js'], ['lint', 'scripts']);
+  gulp.watch(['app/scripts/**/*.js'], ['lint', 'scripts', reload]);
   gulp.watch(['app/images/**/*'], reload);
 });
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -92,14 +92,6 @@ gulp.task('styles', () => {
     .pipe($.sass({
       precision: 10
     }).on('error', $.sass.logError))
-    // Remove any unused CSS
-    .pipe($.if('*.css', $.uncss({
-      html: [
-        'app/index.html'
-      ],
-      // CSS Selectors for UnCSS to ignore
-      ignore: []
-    })))
     .pipe($.autoprefixer(AUTOPREFIXER_BROWSERS))
     .pipe(gulp.dest('.tmp/styles'))
     // Concatenate and minify styles

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "gulp-size": "^2.0.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.0.1",
-    "gulp-uncss": "^1.0.0",
     "gulp-useref": "^3.0.0",
     "psi": "^2.0.2",
     "run-sequence": "^1.0.1",


### PR DESCRIPTION
Thanks to #853 now the `gulp-uncss` plugin gets called at the right place, namely inside the `styles` task instead of the `html` task. But the problem is now that it cuts off too much from the used css. Compare the two sceenshots below:

- With `gulp-uncss`
![screen shot 2016-06-04 at 10 25 16](https://cloud.githubusercontent.com/assets/3122177/16173412/083fbc10-35a1-11e6-96e6-eb2a9e5e58c3.png)

- Without `gulp-uncss`
![screen shot 2016-06-04 at 10 24 13](https://cloud.githubusercontent.com/assets/3122177/16173410/fc6fb246-35a0-11e6-8ecc-2e6217e04230.png)

The difference is reflected through the content of `./tmp/styles/main.css`.

Another possible solution (compared to what this PR proposes) could be the [ignore option](https://github.com/ben-eb/gulp-uncss#ignore) which would solve the issue by the Material Design Lite here, but is not a general solution for people using web-starter-kit for their own used libraries, like Angular Material Design etc.

/cc @addyosmani