### PR TITLE
Add Firebase login command to deploy docs.

### DIFF
--- a/docs/deploy-firebase.md
+++ b/docs/deploy-firebase.md
@@ -15,6 +15,10 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
     can use the `firebase` command from any directory. You may need
     to install the package with `sudo` privileges.
 
+1.  Login to your Firebase account
+
+        firebase login
+
 1.  `cd` into your project directory
 
 1.  Inititalize the Firebase application


### PR DESCRIPTION
If the user is install the Firebase command line tools (for the first time), he will need to login first.
