### PR TITLE
Break long line in gulpfile into smaller lines

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -214,7 +214,10 @@ gulp.task('pagespeed', cb =>
 
 // Copy over the scripts that are used in importScripts as part of the generate-service-worker task.
 gulp.task('copy-sw-scripts', () => {
-  return gulp.src(['node_modules/sw-toolbox/sw-toolbox.js', 'app/scripts/sw/runtime-caching.js'])
+  return gulp.src([
+    'node_modules/sw-toolbox/sw-toolbox.js',
+    'app/scripts/sw/runtime-caching.js'
+  ])
     .pipe(gulp.dest('dist/scripts/sw'));
 });
 


### PR DESCRIPTION
Very simple PR to fix a small lint error in the `gulpfile.babel.js` where a line is too long.

Not sure if this would require creating an independent issue.