### PR TITLE
Add main.js to alternative starting point page

### DIFF
--- a/app/basic.html
+++ b/app/basic.html
@@ -39,6 +39,10 @@
   <body>
     <!-- Add your site or app content here -->
 
+    <!-- build:js scripts/main.min.js -->
+    <script src="scripts/main.js"></script>
+    <!-- endbuild -->
+
     <!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
There are two starting points that user can choose from. The main.js (where registering the service work) is missing if a user decide to use the no layout basic.html instead of the default starting point.