### PR TITLE
Add gulp preinstall to yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.12'
+  - '0.13'
 before_script:
   - npm install -g gulp-cli
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
-script: gulp test
+script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
-script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
   - '5'
   - '4'
   - '0.12'
+before_script:
+  - npm install -g gulp-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.14'
+  - '0.15'
 before_script:
   - npm install -g gulp-cli
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.13'
+  - '0.14'
 before_script:
   - npm install -g gulp-cli
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.15'
+  - '0.16'
 before_script:
   - npm install -g gulp-cli
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ node_js:
   - '5'
   - '4'
   - '0.12'
+before_script:
+  - npm install -g gulp-cli
+script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
-script: gulp
+script: gulp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
-script: npm test
+script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
-script: gulp
+script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ node_js:
   - '5'
   - '4'
   - '0.12'
-before_script:
-  - npm install -g gulp-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
   - '0.12'
 before_script:
   - npm install -g gulp-cli
+script: gulp

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "apache-server-configs": "^2.14.0",
     "babel-core": "^6.14.0",
+	"babel-register": "^6.14.0",
     "babel-preset-es2015": "^6.0.15",
     "browser-sync": "^2.14.0",
     "del": "^2.2.2",


### PR DESCRIPTION
This change to the .travis.yaml file will tell travis-ci to install gulp before running "gulp" as the test