### PR TITLE
Update Node Version tested for and allowed - Resolves #950

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - '8'
+  - '7'
   - '6'
   - '5'
   - '4'
-  - '0.12'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sw-toolbox": "^3.2.1"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4.*"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
This patch removes the oldest versions of Node and only includes those that have LTS support or have existed while node.js has implemented LTS. While its potentially not a good idea to test for non LTS versions from a long term support perspective, there could be users more likely to have those interim version installed and not updated yet.

Resolves - #950 